### PR TITLE
feat(seo): custom translatable SEO engine (meta + OG + Twitter + JSON-LD)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,14 +1,29 @@
 {
-  "permissions": {
-    "allow": [
-      "mcp__laravel-boost__database-schema",
-      "mcp__laravel-boost__application-info",
-      "mcp__laravel-boost__browser-logs",
-      "mcp__laravel-boost__search-docs"
+    "permissions": {
+        "allow": [
+            "mcp__laravel-boost__database-schema",
+            "mcp__laravel-boost__application-info",
+            "mcp__laravel-boost__browser-logs",
+            "mcp__laravel-boost__search-docs",
+            "Bash(vendor/bin/pest*)",
+            "Bash(php artisan test*)",
+            "Bash(composer test*)",
+            "Bash(git add *)",
+            "Bash(git commit -m ' *)",
+            "Bash(composer show *)",
+            "Bash(composer why *)",
+            "Bash(php -v)",
+            "Bash(composer dry-pint)",
+            "Bash(composer dry-rector)",
+            "Bash(tail*)",
+            "Bash(cat*)",
+            "Bash(grep*)",
+            "Bash(vendor/bin/pint*)",
+            "Bash(vendor/bin/phpstan analyse*)"
+        ]
+    },
+    "enableAllProjectMcpServers": true,
+    "enabledMcpjsonServers": [
+        "laravel-boost"
     ]
-  },
-  "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": [
-    "laravel-boost"
-  ]
 }

--- a/app/DataTransferObjects/SeoConfig.php
+++ b/app/DataTransferObjects/SeoConfig.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataTransferObjects;
+
+use App\Enums\RobotsDirective;
+use App\Enums\SchemaType;
+use App\Enums\TwitterCard;
+
+/**
+ * The SEO defaults a model declares (via HasSeo::defaultSeoConfig()). Every text
+ * field is a template resolved against the model's {variables}; null OG/Twitter
+ * fields fall back (og_title → title, twitter_title → og_title → title, etc.).
+ * Stored per-record overrides on the Seo model take precedence over these.
+ */
+readonly class SeoConfig {
+    /**
+     * @param  array<string, string>  $schema  schema.org property => value template (e.g. 'headline' => '{title}')
+     * @param  list<RobotsDirective>  $robots  default robots directives (empty = index, follow)
+     */
+    public function __construct(
+        public SchemaType $schema_type,
+        public string $title,
+        public string $description,
+        public ?string $og_title = null,
+        public ?string $og_description = null,
+        public ?string $og_image = null,
+        public ?string $twitter_title = null,
+        public ?string $twitter_description = null,
+        public ?string $twitter_image = null,
+        public TwitterCard $twitter_card = TwitterCard::SUMMARY_LARGE_IMAGE,
+        public array $schema = [],
+        public array $robots = [],
+    ) {}
+}

--- a/app/DataTransferObjects/SeoData.php
+++ b/app/DataTransferObjects/SeoData.php
@@ -29,4 +29,23 @@ readonly class SeoData {
         public array $twitter = [],
         public array $json_ld = [],
     ) {}
+
+    /**
+     * A copy with the given schema.org nodes prepended to the JSON-LD @graph,
+     * used to add sitewide nodes (WebSite, site identity) ahead of the page node.
+     *
+     * @param  list<array<string, mixed>>  $nodes
+     */
+    public function prependJsonLd(array $nodes): self {
+        return new self(
+            title: $this->title,
+            description: $this->description,
+            canonical: $this->canonical,
+            robots: $this->robots,
+            alternates: $this->alternates,
+            open_graph: $this->open_graph,
+            twitter: $this->twitter,
+            json_ld: [...$nodes, ...$this->json_ld],
+        );
+    }
 }

--- a/app/DataTransferObjects/SeoData.php
+++ b/app/DataTransferObjects/SeoData.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataTransferObjects;
+
+/**
+ * Fully-resolved SEO metadata for a single page, consumed by the public layout.
+ *
+ * Every section is optional: the SEO partial renders only the parts that are
+ * set, so a bare `new SeoData(title: '...')` is valid and emits just a title.
+ * Values are expected to be final (placeholders already resolved) — the partial
+ * does no further processing beyond escaping.
+ */
+readonly class SeoData {
+    /**
+     * @param  list<array{hreflang: string, href: string}>  $alternates  hreflang alternate links
+     * @param  array<string, string>  $open_graph  Open Graph tags keyed by property (e.g. 'og:title' => '...')
+     * @param  array<string, string>  $twitter  Twitter Card tags keyed by name (e.g. 'twitter:card' => '...')
+     * @param  list<array<string, mixed>>  $json_ld  each entry is rendered as a separate ld+json <script>
+     */
+    public function __construct(
+        public ?string $title = null,
+        public ?string $description = null,
+        public ?string $canonical = null,
+        public ?string $robots = null,
+        public array $alternates = [],
+        public array $open_graph = [],
+        public array $twitter = [],
+        public array $json_ld = [],
+    ) {}
+}

--- a/app/Enums/RobotsDirective.php
+++ b/app/Enums/RobotsDirective.php
@@ -4,14 +4,24 @@ declare(strict_types=1);
 
 namespace App\Enums;
 
+use Filament\Support\Contracts\HasLabel;
+
 /**
  * Robots meta directives. Each case's value is the exact token emitted in the
  * `<meta name="robots">` tag, so a set of cases joins into e.g. "noindex,nofollow".
  */
-enum RobotsDirective: string {
+enum RobotsDirective: string implements HasLabel {
     case NOINDEX = 'noindex';
     case NOFOLLOW = 'nofollow';
     case NOARCHIVE = 'noarchive';
     case NOSNIPPET = 'nosnippet';
     case NOIMAGEINDEX = 'noimageindex';
+
+    /**
+     * Admin label: the directive token itself (e.g. "noindex"), matching the
+     * exact value emitted in the robots meta tag.
+     */
+    public function getLabel(): string {
+        return $this->value;
+    }
 }

--- a/app/Enums/RobotsDirective.php
+++ b/app/Enums/RobotsDirective.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Robots meta directives. Each case's value is the exact token emitted in the
+ * `<meta name="robots">` tag, so a set of cases joins into e.g. "noindex,nofollow".
+ */
+enum RobotsDirective: string {
+    case NOINDEX = 'noindex';
+    case NOFOLLOW = 'nofollow';
+    case NOARCHIVE = 'noarchive';
+    case NOSNIPPET = 'nosnippet';
+    case NOIMAGEINDEX = 'noimageindex';
+}

--- a/app/Enums/SchemaType.php
+++ b/app/Enums/SchemaType.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Enums;
 
-enum SchemaType: string {
+use Filament\Support\Contracts\HasLabel;
+
+enum SchemaType: string implements HasLabel {
     case ARTICLE = 'article';
     case BLOG_POSTING = 'blog_posting';
     case CREATIVE_WORK = 'creative_work';
@@ -15,6 +17,13 @@ enum SchemaType: string {
     case PRODUCT = 'product';
     case FAQ_PAGE = 'faq_page';
     case BREADCRUMB_LIST = 'breadcrumb_list';
+
+    /**
+     * Admin label: the schema.org `@type` (a technical proper noun, not localized).
+     */
+    public function getLabel(): string {
+        return $this->schemaOrgType();
+    }
 
     /**
      * The canonical schema.org `@type` identifier emitted in JSON-LD.

--- a/app/Enums/SchemaType.php
+++ b/app/Enums/SchemaType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum SchemaType: string {
+    case ARTICLE = 'article';
+    case BLOG_POSTING = 'blog_posting';
+    case CREATIVE_WORK = 'creative_work';
+    case WEB_PAGE = 'web_page';
+    case WEB_SITE = 'web_site';
+    case PERSON = 'person';
+    case ORGANIZATION = 'organization';
+    case PRODUCT = 'product';
+    case FAQ_PAGE = 'faq_page';
+    case BREADCRUMB_LIST = 'breadcrumb_list';
+
+    /**
+     * The canonical schema.org `@type` identifier emitted in JSON-LD.
+     */
+    public function schemaOrgType(): string {
+        return match ($this) {
+            self::ARTICLE => 'Article',
+            self::BLOG_POSTING => 'BlogPosting',
+            self::CREATIVE_WORK => 'CreativeWork',
+            self::WEB_PAGE => 'WebPage',
+            self::WEB_SITE => 'WebSite',
+            self::PERSON => 'Person',
+            self::ORGANIZATION => 'Organization',
+            self::PRODUCT => 'Product',
+            self::FAQ_PAGE => 'FAQPage',
+            self::BREADCRUMB_LIST => 'BreadcrumbList',
+        };
+    }
+}

--- a/app/Enums/TwitterCard.php
+++ b/app/Enums/TwitterCard.php
@@ -4,13 +4,23 @@ declare(strict_types=1);
 
 namespace App\Enums;
 
+use Filament\Support\Contracts\HasLabel;
+use Illuminate\Support\Str;
+
 /**
  * Twitter Card types. The value is the exact token emitted in the
  * `<meta name="twitter:card">` tag.
  */
-enum TwitterCard: string {
+enum TwitterCard: string implements HasLabel {
     case SUMMARY = 'summary';
     case SUMMARY_LARGE_IMAGE = 'summary_large_image';
     case APP = 'app';
     case PLAYER = 'player';
+
+    /**
+     * Admin label: a human-readable form of the card type (e.g. "Summary Large Image").
+     */
+    public function getLabel(): string {
+        return Str::headline($this->value);
+    }
 }

--- a/app/Enums/TwitterCard.php
+++ b/app/Enums/TwitterCard.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Twitter Card types. The value is the exact token emitted in the
+ * `<meta name="twitter:card">` tag.
+ */
+enum TwitterCard: string {
+    case SUMMARY = 'summary';
+    case SUMMARY_LARGE_IMAGE = 'summary_large_image';
+    case APP = 'app';
+    case PLAYER = 'player';
+}

--- a/app/Filament/Components/SeoFields.php
+++ b/app/Filament/Components/SeoFields.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Components;
+
+use App\Enums\RobotsDirective;
+use App\Enums\SchemaType;
+use App\Enums\TwitterCard;
+use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\KeyValue;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Group;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Illuminate\Support\Collection;
+
+/**
+ * The SEO override fields, bound to a model's `seo` relationship. Every field is
+ * optional: left blank, the public pages fall back to the model's declared SEO
+ * defaults (HasSeo::seoDefaults). Most fields are translatable and follow the
+ * active locale of the surrounding translatable resource.
+ */
+class SeoFields {
+    /**
+     * @param  list<string>  $variables  the {placeholders} this model exposes, shown as a hint
+     */
+    public static function make(array $variables = []): Group {
+        return Group::make()
+            ->relationship('seo')
+            ->schema([
+                Tabs::make('seo')
+                    ->columnSpanFull()
+                    ->tabs([
+                        self::generalTab($variables),
+                        self::socialTab(),
+                        self::advancedTab(),
+                        self::schemaTab(),
+                    ]),
+            ]);
+    }
+
+    /**
+     * @param  list<string>  $variables
+     */
+    private static function generalTab(array $variables): Tab {
+        return Tab::make(__('General'))
+            ->schema([
+                TextInput::make('title')
+                    ->label(__('Meta title'))
+                    ->maxLength(255)
+                    ->hint(self::variablesHint($variables)),
+
+                Textarea::make('description')
+                    ->label(__('Meta description'))
+                    ->rows(3)
+                    ->maxLength(255),
+            ]);
+    }
+
+    private static function socialTab(): Tab {
+        return Tab::make(__('Social'))
+            ->schema([
+                TextInput::make('og_title')
+                    ->label(__('Open Graph title'))
+                    ->maxLength(255),
+
+                Textarea::make('og_description')
+                    ->label(__('Open Graph description'))
+                    ->rows(2),
+
+                TextInput::make('og_image')
+                    ->label(__('Open Graph image URL'))
+                    ->url(),
+
+                TextInput::make('twitter_title')
+                    ->label(__('Twitter title'))
+                    ->maxLength(255),
+
+                Textarea::make('twitter_description')
+                    ->label(__('Twitter description'))
+                    ->rows(2),
+
+                TextInput::make('twitter_image')
+                    ->label(__('Twitter image URL'))
+                    ->url(),
+
+                Select::make('twitter_card')
+                    ->label(__('Twitter card'))
+                    ->options(TwitterCard::class)
+                    ->placeholder(TwitterCard::SUMMARY_LARGE_IMAGE->getLabel()),
+            ]);
+    }
+
+    private static function advancedTab(): Tab {
+        return Tab::make(__('Advanced'))
+            ->schema([
+                TextInput::make('canonical')
+                    ->label(__('Canonical URL'))
+                    ->url(),
+
+                CheckboxList::make('robots')
+                    ->label(__('Robots directives'))
+                    ->options(RobotsDirective::class)
+                    ->columns(2)
+                    ->helperText(__('Leave empty to index and follow. Note: noindex also removes the page from the sitemap.')),
+            ]);
+    }
+
+    private static function schemaTab(): Tab {
+        return Tab::make(__('Schema'))
+            ->schema([
+                Select::make('schema_type')
+                    ->label(__('Schema type'))
+                    ->options(SchemaType::class)
+                    ->placeholder(__('Use the default for this content')),
+
+                KeyValue::make('schema_overrides')
+                    ->label(__('Schema property overrides'))
+                    ->keyLabel(__('Property'))
+                    ->valueLabel(__('Value or template'))
+                    ->helperText(__('Override individual schema.org properties; leave a property out to keep its automatic value.')),
+            ]);
+    }
+
+    /**
+     * @param  list<string>  $variables
+     */
+    private static function variablesHint(array $variables): ?string {
+        if ($variables === []) {
+            return null;
+        }
+
+        return __('Available variables: :vars', [
+            'vars' => Collection::make($variables)->map(fn (string $variable): string => '{'.$variable.'}')->implode(', '),
+        ]);
+    }
+}

--- a/app/Filament/Components/SeoFields.php
+++ b/app/Filament/Components/SeoFields.php
@@ -29,7 +29,12 @@ class SeoFields {
      */
     public static function make(array $variables = []): Group {
         return Group::make()
-            ->relationship('seo')
+            // Only persist a Seo row when at least one field is filled; an
+            // all-blank section saves nothing (and prunes an existing empty row),
+            // keeping "no overrides" as the absence of a row.
+            ->relationship('seo', condition: fn (?array $state): bool => collect($state ?? [])
+                ->except(['id', 'seoable_type', 'seoable_id', 'created_at', 'updated_at'])
+                ->contains(fn (mixed $value): bool => filled($value)))
             ->schema([
                 Tabs::make('seo')
                     ->columnSpanFull()

--- a/app/Filament/Components/SeoFields.php
+++ b/app/Filament/Components/SeoFields.php
@@ -32,9 +32,7 @@ class SeoFields {
             // Only persist a Seo row when at least one field is filled; an
             // all-blank section saves nothing (and prunes an existing empty row),
             // keeping "no overrides" as the absence of a row.
-            ->relationship('seo', condition: fn (?array $state): bool => collect($state ?? [])
-                ->except(['id', 'seoable_type', 'seoable_id', 'created_at', 'updated_at'])
-                ->contains(fn (mixed $value): bool => filled($value)))
+            ->relationship('seo', condition: fn (?array $state): bool => self::hasAnyOverride($state))
             ->schema([
                 Tabs::make('seo')
                     ->columnSpanFull()
@@ -128,6 +126,18 @@ class SeoFields {
                     ->valueLabel(__('Value or template'))
                     ->helperText(__('Override individual schema.org properties; leave a property out to keep its automatic value.')),
             ]);
+    }
+
+    /**
+     * Whether the SEO section holds at least one override, ignoring the Seo
+     * row's own keys/timestamps. Drives whether a row is saved or pruned.
+     *
+     * @param  array<array-key, mixed>|null  $state
+     */
+    private static function hasAnyOverride(?array $state): bool {
+        return Collection::make($state ?? [])
+            ->except(['id', 'seoable_type', 'seoable_id', 'created_at', 'updated_at'])
+            ->contains(fn (mixed $value): bool => filled($value));
     }
 
     /**

--- a/app/Filament/Pages/SeoSettings.php
+++ b/app/Filament/Pages/SeoSettings.php
@@ -80,15 +80,7 @@ class SeoSettings extends Page {
                                 ->placeholder(config()->string('app.name')),
 
                             Tabs::make('description')
-                                ->tabs(array_map(
-                                    fn (string $locale): Tab => Tab::make(strtoupper($locale))
-                                        ->schema([
-                                            Textarea::make("description.{$locale}")
-                                                ->label(__('Description'))
-                                                ->rows(3),
-                                        ]),
-                                    $this->locales(),
-                                )),
+                                ->tabs(array_map($this->localeDescriptionTab(...), $this->locales())),
 
                             Repeater::make('social_profiles')
                                 ->label(__('Social profiles'))
@@ -152,6 +144,18 @@ class SeoSettings extends Page {
 
     public function getRecord(): SeoSetting {
         return SeoSetting::query()->firstOrNew();
+    }
+
+    /**
+     * One tab editing the translatable description for a single locale.
+     */
+    private function localeDescriptionTab(string $locale): Tab {
+        return Tab::make(strtoupper($locale))
+            ->schema([
+                Textarea::make("description.{$locale}")
+                    ->label(__('Description'))
+                    ->rows(3),
+            ]);
     }
 
     /**

--- a/app/Filament/Pages/SeoSettings.php
+++ b/app/Filament/Pages/SeoSettings.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages;
+
+use App\Enums\SchemaType;
+use App\Models\SeoSetting;
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Form;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Facades\App;
+
+/**
+ * Site-wide SEO identity and defaults, edited on the single SeoSetting row.
+ *
+ * @property-read Schema $form
+ */
+class SeoSettings extends Page {
+    protected string $view = 'filament.pages.seo-settings';
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedGlobeAlt;
+
+    /** @var array<string, mixed> */
+    public array $data = [];
+
+    public function mount(): void {
+        $record = $this->getRecord();
+
+        $this->form->fill([
+            'type' => $record->type->value,
+            'name' => $record->name,
+            'description' => $this->translationsFor($record, 'description'),
+            'social_profiles' => $record->social_profiles ?? [],
+            'default_og_image' => $record->default_og_image,
+            'title_separator' => $record->title_separator,
+            'website_schema' => $record->website_schema,
+        ]);
+    }
+
+    public static function getNavigationLabel(): string {
+        return __('SEO settings');
+    }
+
+    public function getTitle(): string {
+        return __('SEO settings');
+    }
+
+    public function form(Schema $schema): Schema {
+        return $schema
+            ->components([
+                Form::make([
+                    Section::make(__('Identity'))
+                        ->description(__('Who the site represents — feeds the WebSite and Person/Organization schema.'))
+                        ->schema([
+                            Select::make('type')
+                                ->label(__('Identity type'))
+                                ->options([
+                                    SchemaType::PERSON->value => SchemaType::PERSON->getLabel(),
+                                    SchemaType::ORGANIZATION->value => SchemaType::ORGANIZATION->getLabel(),
+                                ])
+                                ->required(),
+
+                            TextInput::make('name')
+                                ->label(__('Name'))
+                                ->maxLength(255)
+                                ->placeholder(config()->string('app.name')),
+
+                            Tabs::make('description')
+                                ->tabs(array_map(
+                                    fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                        ->schema([
+                                            Textarea::make("description.{$locale}")
+                                                ->label(__('Description'))
+                                                ->rows(3),
+                                        ]),
+                                    $this->locales(),
+                                )),
+
+                            Repeater::make('social_profiles')
+                                ->label(__('Social profiles'))
+                                ->simple(
+                                    TextInput::make('url')
+                                        ->url()
+                                        ->required()
+                                )
+                                ->helperText(__('Profile URLs emitted as the schema "sameAs" links.'))
+                                ->addActionLabel(__('Add profile'))
+                                ->defaultItems(0),
+                        ]),
+
+                    Section::make(__('Defaults'))
+                        ->schema([
+                            Toggle::make('website_schema')
+                                ->label(__('Emit WebSite schema')),
+
+                            TextInput::make('default_og_image')
+                                ->label(__('Default Open Graph image URL'))
+                                ->url(),
+
+                            TextInput::make('title_separator')
+                                ->label(__('Title separator'))
+                                ->required()
+                                ->maxLength(10),
+                        ]),
+                ])
+                    ->livewireSubmitHandler('save')
+                    ->footer([
+                        Actions::make([
+                            Action::make('save')
+                                ->label(__('Save'))
+                                ->submit('save')
+                                ->keyBindings(['mod+s']),
+                        ]),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void {
+        /** @var array<string, mixed> $data */
+        $data = $this->form->getState();
+
+        $record = $this->getRecord();
+
+        /** @var array<string, string> $descriptions */
+        $descriptions = $data['description'] ?? [];
+        unset($data['description']);
+
+        $record->fill($data);
+        $record->setTranslations('description', array_filter($descriptions, fn (string $value): bool => $value !== ''));
+        $record->save();
+
+        Notification::make()
+            ->success()
+            ->title(__('SEO settings saved'))
+            ->send();
+    }
+
+    public function getRecord(): SeoSetting {
+        return SeoSetting::query()->firstOrNew();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function locales(): array {
+        return array_keys(App::supportedLocales());
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function translationsFor(SeoSetting $record, string $attribute): array {
+        $stored = $record->getTranslations($attribute);
+        $translations = [];
+
+        foreach ($this->locales() as $locale) {
+            $value = $stored[$locale] ?? '';
+            $translations[$locale] = is_string($value) ? $value : '';
+        }
+
+        return $translations;
+    }
+}

--- a/app/Filament/Resources/BlogArticles/Schemas/BlogArticleForm.php
+++ b/app/Filament/Resources/BlogArticles/Schemas/BlogArticleForm.php
@@ -6,6 +6,7 @@ namespace App\Filament\Resources\BlogArticles\Schemas;
 
 use App\Enums\BlogArticleStatuses;
 use App\Enums\TagTypes;
+use App\Filament\Components\SeoFields;
 use App\Models\Project;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\MorphToSelect;
@@ -177,6 +178,13 @@ class BlogArticleForm {
                             ->columnSpanFull(),
                     ])
                     ->columns(1),
+
+                Section::make(__('SEO'))
+                    ->description(__('Optional overrides. Left blank, search-engine metadata is generated automatically from the article.'))
+                    ->collapsed()
+                    ->schema([
+                        SeoFields::make(['title', 'excerpt', 'author', 'category', 'tags', 'site_name', 'published_date', 'current_year']),
+                    ]),
             ]);
     }
 }

--- a/app/Filament/Resources/Projects/Schemas/ProjectForm.php
+++ b/app/Filament/Resources/Projects/Schemas/ProjectForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\Projects\Schemas;
 
 use App\Enums\TagTypes;
+use App\Filament\Components\SeoFields;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
@@ -144,6 +145,13 @@ class ProjectForm {
                             ->default(false),
                     ])
                     ->columns(1),
+
+                Section::make(__('SEO'))
+                    ->description(__('Optional overrides. Left blank, search-engine metadata is generated automatically from the project.'))
+                    ->collapsed()
+                    ->schema([
+                        SeoFields::make(['title', 'excerpt', 'client', 'tags', 'site_name', 'current_year']),
+                    ]),
             ]);
     }
 }

--- a/app/Livewire/Pages/BlogArticle/BlogArticleShow.php
+++ b/app/Livewire/Pages/BlogArticle/BlogArticleShow.php
@@ -16,7 +16,7 @@ class BlogArticleShow extends Component {
     public ?BlogArticle $next = null;
 
     public function mount(BlogArticle $blog_article): void {
-        $this->blog_article = $blog_article->load(['tags', 'media', 'relatables.relatable']);
+        $this->blog_article = $blog_article->load(['tags', 'media', 'relatables.relatable', 'author', 'seo']);
         $this->previous = $blog_article->previous();
         $this->next = $blog_article->next();
     }
@@ -25,7 +25,9 @@ class BlogArticleShow extends Component {
         $view = view('pages.blog-article.show')
             ->with(['related_blog_articles' => $this->blog_article->relatedBlogArticles()]);
 
-        $view->title($this->blog_article->title);
+        $view->layout('layouts.public.index', [
+            'seo_data' => $this->blog_article->toSeoData(),
+        ]);
 
         return $view;
     }

--- a/app/Livewire/Pages/Project/ProjectShow.php
+++ b/app/Livewire/Pages/Project/ProjectShow.php
@@ -12,11 +12,13 @@ class ProjectShow extends Component {
     public Project $project;
 
     public function mount(Project $project): void {
-        $this->project = $project->load(['tags', 'media']);
+        $this->project = $project->load(['tags', 'media', 'seo']);
     }
 
     public function render(): View {
         return view('pages.projects.show')
-            ->title($this->project->title);
+            ->layout('layouts.public.index', [
+                'seo_data' => $this->project->toSeoData(),
+            ]);
     }
 }

--- a/app/Macros/Str/ReplacePlaceholdersMacro.php
+++ b/app/Macros/Str/ReplacePlaceholdersMacro.php
@@ -13,14 +13,15 @@ class ReplacePlaceholdersMacro implements Macro {
     public static function register(): array {
         return [
             'replacePlaceholders',
-            function (string $string, object|array|null $replacements = null): string {
-                $regex = '/\{(\w+)\}/';
-                \Safe\preg_match_all($regex, $string, $matches, PREG_SET_ORDER);
+            function (string $string, object|array|null $replacements = null, bool $strip_unmatched = false): string {
+                \Safe\preg_match_all('/\{(\w+)\}/', $string, $matches, PREG_SET_ORDER);
 
                 $special_cases = [
                     'timestamp' => now()->timestamp,
                     'random' => uniqid(Str::random(8)),
                 ];
+
+                $arrayable = $replacements instanceof Arrayable ? $replacements->toArray() : [];
 
                 foreach ($matches as [$placeholder, $field]) {
                     $replacement = match (true) {
@@ -28,9 +29,9 @@ class ReplacePlaceholdersMacro implements Macro {
                         is_array($replacements) && array_key_exists($field, $replacements) => $replacements[$field],
                         is_object($replacements) && property_exists($replacements, $field) => $replacements->{$field},
                         is_object($replacements) && method_exists($replacements, $field) => $replacements->{$field}(),
-                        $replacements instanceof Arrayable && array_key_exists($field, $replacements->toArray()) => $replacements->toArray()[$field],
+                        array_key_exists($field, $arrayable) => $arrayable[$field],
                         function_exists($field) => $field(),
-                        default => $placeholder
+                        default => $strip_unmatched ? '' : $placeholder,
                     };
 
                     if (! is_string($replacement)) {

--- a/app/Models/BlogArticle.php
+++ b/app/Models/BlogArticle.php
@@ -50,7 +50,7 @@ use Spatie\Translatable\HasTranslations;
  * @property-read string $featured_image_url
  * @property-read string $summary_or_excerpt
  * @property-read User $author
- * @property-read Seo $seo
+ * @property-read Seo|null $seo
  */
 class BlogArticle extends Model implements HasMedia, LocalizedUrlRoutable, Sitemapable {
     /** @use HasFactory<BlogArticleFactory> */

--- a/app/Models/BlogArticle.php
+++ b/app/Models/BlogArticle.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\DataTransferObjects\SeoConfig;
 use App\Enums\BlogArticleStatuses;
+use App\Enums\SchemaType;
+use App\Enums\TagTypes;
 use App\Models\Concerns\HasRoutableSlug;
+use App\Models\Concerns\HasSeo;
 use App\Models\Concerns\HasSitemapTag;
 use App\Models\Concerns\LogsAllDirtyChanges;
 use App\Models\Concerns\ResolvesRoutBindingByLocalizedSlug;
@@ -45,10 +49,12 @@ use Spatie\Translatable\HasTranslations;
  * @property-read bool $can_be_crawled
  * @property-read string $featured_image_url
  * @property-read string $summary_or_excerpt
+ * @property-read User $author
+ * @property-read Seo $seo
  */
 class BlogArticle extends Model implements HasMedia, LocalizedUrlRoutable, Sitemapable {
     /** @use HasFactory<BlogArticleFactory> */
-    use HasCurrentLocaleTranslationScope, HasFactory, HasRoutableSlug, HasSitemapTag, HasTags, HasTranslations, InteractsWithMedia, LogsAllDirtyChanges, ResolvesRoutBindingByLocalizedSlug;
+    use HasCurrentLocaleTranslationScope, HasFactory, HasRoutableSlug, HasSeo, HasSitemapTag, HasTags, HasTranslations, InteractsWithMedia, LogsAllDirtyChanges, ResolvesRoutBindingByLocalizedSlug;
 
     /** @var list<string> */
     public array $translatable = ['title', 'slug', 'summary', 'content'];
@@ -135,6 +141,46 @@ class BlogArticle extends Model implements HasMedia, LocalizedUrlRoutable, Sitem
     /** @return Attribute<bool, never> */
     protected function canBeCrawled(): Attribute {
         return Attribute::get(fn () => $this->status->allowsCrawling() && ($this->published_at?->isNowOrPast() ?? false));
+    }
+
+    public function seoDefaults(): SeoConfig {
+        return new SeoConfig(
+            schema_type: SchemaType::BLOG_POSTING,
+            title: '{title} {title_separator} {site_name}',
+            description: '{excerpt}',
+            og_image: '{featured_image}',
+            schema: [
+                'headline' => '{title}',
+                'description' => '{excerpt}',
+                'image' => '{featured_image}',
+                'datePublished' => '{published_iso}',
+                'dateModified' => '{modified_iso}',
+                'inLanguage' => '{locale}',
+                'articleSection' => '{category}',
+                'author' => '{author}',
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function seoVariables(): array {
+        return [
+            'title' => $this->title,
+            'excerpt' => $this->summary_or_excerpt,
+            'author' => $this->author->name,
+            'category' => $this->tags->where('type', TagTypes::BLOG_CATEGORY->value)->pluck('name')->implode(', '),
+            'tags' => $this->tags->where('type', TagTypes::TAG->value)->pluck('name')->implode(', '),
+            'featured_image' => $this->featured_image_url,
+            'published_date' => $this->published_at?->translatedFormat('d F Y') ?? '',
+            'published_iso' => $this->published_at?->toIso8601String() ?? '',
+            'modified_iso' => $this->updated_at->toIso8601String(),
+        ];
+    }
+
+    protected function isCrawlableByStatus(): bool {
+        return $this->can_be_crawled;
     }
 
     /** @param Builder<self> $query */

--- a/app/Models/Concerns/HasSeo.php
+++ b/app/Models/Concerns/HasSeo.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
-use Illuminate\Support\Uri;
 use Mcamara\LaravelLocalization\Facades\LaravelLocalization;
 
 /**
@@ -65,17 +64,17 @@ trait HasSeo {
         $seo = $this->seo;
         $vars = $this->resolvedSeoVariables();
 
-        $title = $this->resolveTemplate($seo->title ?? $defaults->title, $vars);
-        $description = $this->resolveTemplate($seo->description ?? $defaults->description, $vars);
-        $og_title = $this->resolveTemplate($seo->og_title ?? $defaults->og_title, $vars) ?: $title;
-        $og_description = $this->resolveTemplate($seo->og_description ?? $defaults->og_description, $vars) ?: $description;
-        $og_image = $this->resolveTemplate($seo->og_image ?? $defaults->og_image, $vars);
-        $twitter_title = $this->resolveTemplate($seo->twitter_title ?? $defaults->twitter_title, $vars) ?: $og_title;
-        $twitter_description = $this->resolveTemplate($seo->twitter_description ?? $defaults->twitter_description, $vars) ?: $og_description;
-        $twitter_image = $this->resolveTemplate($seo->twitter_image ?? $defaults->twitter_image, $vars) ?: $og_image;
+        $title = $this->resolveTemplate($this->override($seo, 'title') ?? $defaults->title, $vars);
+        $description = $this->resolveTemplate($this->override($seo, 'description') ?? $defaults->description, $vars);
+        $og_title = $this->resolveTemplate($this->override($seo, 'og_title') ?? $defaults->og_title, $vars) ?: $title;
+        $og_description = $this->resolveTemplate($this->override($seo, 'og_description') ?? $defaults->og_description, $vars) ?: $description;
+        $og_image = $this->resolveTemplate($this->override($seo, 'og_image') ?? $defaults->og_image, $vars);
+        $twitter_title = $this->resolveTemplate($this->override($seo, 'twitter_title') ?? $defaults->twitter_title, $vars) ?: $og_title;
+        $twitter_description = $this->resolveTemplate($this->override($seo, 'twitter_description') ?? $defaults->twitter_description, $vars) ?: $og_description;
+        $twitter_image = $this->resolveTemplate($this->override($seo, 'twitter_image') ?? $defaults->twitter_image, $vars) ?: $og_image;
         $card = ($seo->twitter_card ?? $defaults->twitter_card)->value;
 
-        $canonical = $seo->canonical
+        $canonical = $this->override($seo, 'canonical')
             ?: $this->localizedUrl(App::getLocale());
 
         return new SeoData(
@@ -105,6 +104,18 @@ trait HasSeo {
     }
 
     /**
+     * A stored override for a translatable string field in the current locale,
+     * or null when unset there. Read WITHOUT the spatie fallback locale, so an
+     * override set only in another locale does not leak in — the field falls
+     * through to the model's default template instead.
+     */
+    private function override(Seo $seo, string $field): ?string {
+        $value = $seo->getTranslation($field, App::getLocale(), false);
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /**
      * @return array<string, string>
      */
     private function resolvedSeoVariables(): array {
@@ -118,12 +129,21 @@ trait HasSeo {
      * @return array<string, string>
      */
     private function globalSeoVariables(): array {
+        $settings = SeoSetting::current();
+
         return [
-            'site_name' => config()->string('app.name'),
-            'title_separator' => SeoSetting::current()->title_separator,
+            'site_name' => $this->siteName(),
+            'title_separator' => $settings->title_separator,
             'locale' => App::getLocale(),
             'current_year' => (string) now()->year,
         ];
+    }
+
+    /**
+     * The configured SEO site name, falling back to the app name.
+     */
+    private function siteName(): string {
+        return SeoSetting::current()->name ?? config()->string('app.name');
     }
 
     /**
@@ -140,7 +160,13 @@ trait HasSeo {
     }
 
     private function resolveRobots(Seo $seo, SeoConfig $config): ?string {
-        $directives = $seo->robots ?? array_map(fn (RobotsDirective $directive): string => $directive->value, $config->robots);
+        // Read robots for the current locale only (no fallback), so a per-locale
+        // noindex does not bleed into other locales via the spatie fallback.
+        $stored = $seo->getTranslation('robots', App::getLocale(), false);
+
+        $directives = is_array($stored) && $stored !== []
+            ? array_values(array_filter($stored, 'is_string'))
+            : array_map(fn (RobotsDirective $directive): string => $directive->value, $config->robots);
 
         if (! $this->isCrawlableByStatus()) {
             $directives[] = RobotsDirective::NOINDEX->value;
@@ -171,10 +197,7 @@ trait HasSeo {
     }
 
     private function localizedUrl(string $locale): string {
-        /** @var Uri $uri */
-        $uri = Route::localizedUrl($locale, $this->getSitemapRoute($locale));
-
-        return $uri->__toString();
+        return Route::localizedUrlString($locale, $this->getSitemapRoute($locale));
     }
 
     /**
@@ -188,7 +211,7 @@ trait HasSeo {
             'og:title' => $title,
             'og:description' => $description,
             'og:url' => $url,
-            'og:site_name' => config()->string('app.name'),
+            'og:site_name' => $this->siteName(),
             'og:locale' => $regional,
             'og:image' => $image,
         ], fn (string $value): bool => $value !== '');
@@ -216,8 +239,9 @@ trait HasSeo {
     private function primarySchemaNode(SeoConfig $config, Seo $seo, array $vars): array {
         $type = ($seo->schema_type ?? $config->schema_type)->schemaOrgType();
 
-        /** @var array<string, mixed> $overrides */
-        $overrides = $seo->schema_overrides ?? [];
+        // Per-property overrides for the current locale only (no fallback).
+        $stored = $seo->getTranslation('schema_overrides', App::getLocale(), false);
+        $overrides = is_array($stored) ? $stored : [];
 
         $node = ['@type' => $type];
 

--- a/app/Models/Concerns/HasSeo.php
+++ b/app/Models/Concerns/HasSeo.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+use App\DataTransferObjects\SeoConfig;
+use App\DataTransferObjects\SeoData;
+use App\Enums\RobotsDirective;
+use App\Models\Seo;
+use App\Models\SeoSetting;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Illuminate\Support\Uri;
+use Mcamara\LaravelLocalization\Facades\LaravelLocalization;
+
+/**
+ * Gives a model resolved, translatable SEO: it merges the model's declared
+ * defaults (defaultSeoConfig) with the stored per-record overrides (the Seo
+ * relation), resolves {variables} via Str::replacePlaceholders, and produces a
+ * SeoData for the current locale. Crawl rules (status + SEO noindex) are
+ * reconciled in one place (isIndexable / the robots meta).
+ */
+trait HasSeo {
+    /**
+     * The model's SEO defaults (templates, schema mapping, default robots).
+     */
+    abstract public function seoDefaults(): SeoConfig;
+
+    /**
+     * Template variables for this model in the current locale, e.g.
+     * ['title' => $this->title, 'excerpt' => $this->summary_or_excerpt].
+     *
+     * @return array<string, string>
+     */
+    abstract protected function seoVariables(): array;
+
+    /**
+     * Whether the model is crawlable by its own status rules (publication,
+     * status enum, …) — i.e. ignoring the per-record SEO noindex override.
+     */
+    abstract protected function isCrawlableByStatus(): bool;
+
+    /**
+     * The localized public route for the given locale. Also required by
+     * HasSitemapTag, which every SEO-aware model already uses.
+     */
+    abstract protected function getSitemapRoute(string $locale): string;
+
+    /**
+     * The per-record SEO overrides. withDefault() yields an empty (non-persisted)
+     * Seo when no row exists, so $this->seo is always a Seo whose every field is
+     * null — each one then falls back to the model's declared defaults.
+     *
+     * @return MorphOne<Seo, $this>
+     */
+    public function seo(): MorphOne {
+        return $this->morphOne(Seo::class, 'seoable')->withDefault();
+    }
+
+    public function toSeoData(): SeoData {
+        $defaults = $this->seoDefaults();
+        $seo = $this->seo;
+        $vars = $this->resolvedSeoVariables();
+
+        $title = $this->resolveTemplate($seo->title ?? $defaults->title, $vars);
+        $description = $this->resolveTemplate($seo->description ?? $defaults->description, $vars);
+        $og_title = $this->resolveTemplate($seo->og_title ?? $defaults->og_title, $vars) ?: $title;
+        $og_description = $this->resolveTemplate($seo->og_description ?? $defaults->og_description, $vars) ?: $description;
+        $og_image = $this->resolveTemplate($seo->og_image ?? $defaults->og_image, $vars);
+        $twitter_title = $this->resolveTemplate($seo->twitter_title ?? $defaults->twitter_title, $vars) ?: $og_title;
+        $twitter_description = $this->resolveTemplate($seo->twitter_description ?? $defaults->twitter_description, $vars) ?: $og_description;
+        $twitter_image = $this->resolveTemplate($seo->twitter_image ?? $defaults->twitter_image, $vars) ?: $og_image;
+        $card = ($seo->twitter_card ?? $defaults->twitter_card)->value;
+
+        $canonical = $seo->canonical
+            ?: $this->localizedUrl(App::getLocale());
+
+        return new SeoData(
+            title: $title ?: null,
+            description: $description ?: null,
+            canonical: $canonical,
+            robots: $this->resolveRobots($seo, $defaults),
+            alternates: $this->seoAlternates(),
+            open_graph: $this->openGraphTags($og_title, $og_description, $og_image, $canonical),
+            twitter: $this->twitterTags($card, $twitter_title, $twitter_description, $twitter_image),
+            json_ld: [$this->primarySchemaNode($defaults, $seo, $vars)],
+        );
+    }
+
+    /**
+     * Whether the model may be indexed in the given locale: crawlable by status
+     * AND not flagged noindex via its SEO overrides for that locale.
+     */
+    public function isIndexable(?string $locale = null): bool {
+        return $this->isCrawlableByStatus() && ! $this->hasSeoNoindex($locale ?? App::getLocale());
+    }
+
+    private function hasSeoNoindex(string $locale): bool {
+        $robots = $this->seo->getTranslation('robots', $locale, false);
+
+        return is_array($robots) && in_array(RobotsDirective::NOINDEX->value, $robots, true);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function resolvedSeoVariables(): array {
+        return [
+            ...$this->globalSeoVariables(),
+            ...$this->seoVariables(),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function globalSeoVariables(): array {
+        return [
+            'site_name' => config()->string('app.name'),
+            'title_separator' => SeoSetting::current()->title_separator,
+            'locale' => App::getLocale(),
+            'current_year' => (string) now()->year,
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $vars
+     */
+    private function resolveTemplate(?string $template, array $vars): string {
+        if (! $template) {
+            return '';
+        }
+
+        $resolved = Str::replacePlaceholders($template, $vars, strip_unmatched: true);
+
+        return trim((string) \Safe\preg_replace('/\s+/', ' ', $resolved));
+    }
+
+    private function resolveRobots(Seo $seo, SeoConfig $config): ?string {
+        $directives = $seo->robots ?? array_map(fn (RobotsDirective $directive): string => $directive->value, $config->robots);
+
+        if (! $this->isCrawlableByStatus()) {
+            $directives[] = RobotsDirective::NOINDEX->value;
+        }
+
+        $directives = array_values(array_unique($directives));
+
+        return $directives === [] ? null : implode(',', $directives);
+    }
+
+    /**
+     * @return list<array{hreflang: string, href: string}>
+     */
+    private function seoAlternates(): array {
+        $alternates = [];
+
+        /** @var list<string> $locales */
+        $locales = $this->locales();
+
+        foreach ($locales as $locale) {
+            $alternates[] = [
+                'hreflang' => $locale,
+                'href' => $this->localizedUrl($locale),
+            ];
+        }
+
+        return $alternates;
+    }
+
+    private function localizedUrl(string $locale): string {
+        /** @var Uri $uri */
+        $uri = Route::localizedUrl($locale, $this->getSitemapRoute($locale));
+
+        return $uri->__toString();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function openGraphTags(string $title, string $description, string $image, string $url): array {
+        $regional = LaravelLocalization::getCurrentLocaleRegional() ?: App::getLocale();
+
+        return array_filter([
+            'og:type' => 'article',
+            'og:title' => $title,
+            'og:description' => $description,
+            'og:url' => $url,
+            'og:site_name' => config()->string('app.name'),
+            'og:locale' => $regional,
+            'og:image' => $image,
+        ], fn (string $value): bool => $value !== '');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function twitterTags(string $card, string $title, string $description, string $image): array {
+        return array_filter([
+            'twitter:card' => $card,
+            'twitter:title' => $title,
+            'twitter:description' => $description,
+            'twitter:image' => $image,
+        ], fn (string $value): bool => $value !== '');
+    }
+
+    /**
+     * The page's primary schema.org node (e.g. BlogPosting/CreativeWork), built
+     * from the schema property templates with stored per-property overrides.
+     *
+     * @param  array<string, string>  $vars
+     * @return array<string, mixed>
+     */
+    private function primarySchemaNode(SeoConfig $config, Seo $seo, array $vars): array {
+        $type = ($seo->schema_type ?? $config->schema_type)->schemaOrgType();
+
+        /** @var array<string, mixed> $overrides */
+        $overrides = $seo->schema_overrides ?? [];
+
+        $node = ['@type' => $type];
+
+        foreach ($config->schema as $property => $template) {
+            $override = $overrides[$property] ?? null;
+            $value = $this->resolveTemplate(is_string($override) ? $override : $template, $vars);
+
+            if ($value !== '') {
+                $node[$property] = $value;
+            }
+        }
+
+        return $node;
+    }
+}

--- a/app/Models/Concerns/HasSeo.php
+++ b/app/Models/Concerns/HasSeo.php
@@ -49,14 +49,12 @@ trait HasSeo {
     abstract protected function getSitemapRoute(string $locale): string;
 
     /**
-     * The per-record SEO overrides. withDefault() yields an empty (non-persisted)
-     * Seo when no row exists, so $this->seo is always a Seo whose every field is
-     * null — each one then falls back to the model's declared defaults.
+     * The per-record SEO overrides, or null when none have been stored.
      *
      * @return MorphOne<Seo, $this>
      */
     public function seo(): MorphOne {
-        return $this->morphOne(Seo::class, 'seoable')->withDefault();
+        return $this->morphOne(Seo::class, 'seoable');
     }
 
     public function toSeoData(): SeoData {
@@ -64,17 +62,18 @@ trait HasSeo {
         $seo = $this->seo;
         $vars = $this->resolvedSeoVariables();
 
-        $title = $this->resolveTemplate($this->override($seo, 'title') ?? $defaults->title, $vars);
-        $description = $this->resolveTemplate($this->override($seo, 'description') ?? $defaults->description, $vars);
-        $og_title = $this->resolveTemplate($this->override($seo, 'og_title') ?? $defaults->og_title, $vars) ?: $title;
-        $og_description = $this->resolveTemplate($this->override($seo, 'og_description') ?? $defaults->og_description, $vars) ?: $description;
-        $og_image = $this->resolveTemplate($this->override($seo, 'og_image') ?? $defaults->og_image, $vars);
-        $twitter_title = $this->resolveTemplate($this->override($seo, 'twitter_title') ?? $defaults->twitter_title, $vars) ?: $og_title;
-        $twitter_description = $this->resolveTemplate($this->override($seo, 'twitter_description') ?? $defaults->twitter_description, $vars) ?: $og_description;
-        $twitter_image = $this->resolveTemplate($this->override($seo, 'twitter_image') ?? $defaults->twitter_image, $vars) ?: $og_image;
-        $card = ($seo->twitter_card ?? $defaults->twitter_card)->value;
+        $title = $this->substituteSeoVars($this->seoOverride($seo, 'title') ?? $defaults->title, $vars);
+        $description = $this->substituteSeoVars($this->seoOverride($seo, 'description') ?? $defaults->description, $vars);
+        $og_title = $this->substituteSeoVars($this->seoOverride($seo, 'og_title') ?? $defaults->og_title, $vars) ?: $title;
+        $og_description = $this->substituteSeoVars($this->seoOverride($seo, 'og_description') ?? $defaults->og_description, $vars) ?: $description;
+        $og_image = $this->substituteSeoVars($this->seoOverride($seo, 'og_image') ?? $defaults->og_image, $vars);
+        $twitter_title = $this->substituteSeoVars($this->seoOverride($seo, 'twitter_title') ?? $defaults->twitter_title, $vars) ?: $og_title;
+        $twitter_description = $this->substituteSeoVars($this->seoOverride($seo, 'twitter_description') ?? $defaults->twitter_description, $vars) ?: $og_description;
+        $twitter_image = $this->substituteSeoVars($this->seoOverride($seo, 'twitter_image') ?? $defaults->twitter_image, $vars) ?: $og_image;
+        $stored_card = $seo?->twitter_card;
+        $card = ($stored_card ?? $defaults->twitter_card)->value;
 
-        $canonical = $this->override($seo, 'canonical')
+        $canonical = $this->seoOverride($seo, 'canonical')
             ?: $this->localizedUrl(App::getLocale());
 
         return new SeoData(
@@ -98,19 +97,19 @@ trait HasSeo {
     }
 
     private function hasSeoNoindex(string $locale): bool {
-        $robots = $this->seo->getTranslation('robots', $locale, false);
+        $robots = $this->seo?->getTranslation('robots', $locale, false);
 
         return is_array($robots) && in_array(RobotsDirective::NOINDEX->value, $robots, true);
     }
 
     /**
      * A stored override for a translatable string field in the current locale,
-     * or null when unset there. Read WITHOUT the spatie fallback locale, so an
-     * override set only in another locale does not leak in — the field falls
-     * through to the model's default template instead.
+     * or null when there is no Seo row or no value for that locale. Read WITHOUT
+     * the spatie fallback locale, so an override set only in another locale does
+     * not leak in — the field falls through to the model's default template.
      */
-    private function override(Seo $seo, string $field): ?string {
-        $value = $seo->getTranslation($field, App::getLocale(), false);
+    private function seoOverride(?Seo $seo, string $field): ?string {
+        $value = $seo?->getTranslation($field, App::getLocale(), false);
 
         return is_string($value) && $value !== '' ? $value : null;
     }
@@ -147,9 +146,12 @@ trait HasSeo {
     }
 
     /**
+     * Substitute the SEO {variables} in a template, dropping any unmatched ones,
+     * then collapse the whitespace they may leave behind.
+     *
      * @param  array<string, string>  $vars
      */
-    private function resolveTemplate(?string $template, array $vars): string {
+    private function substituteSeoVars(?string $template, array $vars): string {
         if (! $template) {
             return '';
         }
@@ -159,10 +161,10 @@ trait HasSeo {
         return trim((string) \Safe\preg_replace('/\s+/', ' ', $resolved));
     }
 
-    private function resolveRobots(Seo $seo, SeoConfig $config): ?string {
+    private function resolveRobots(?Seo $seo, SeoConfig $config): ?string {
         // Read robots for the current locale only (no fallback), so a per-locale
         // noindex does not bleed into other locales via the spatie fallback.
-        $stored = $seo->getTranslation('robots', App::getLocale(), false);
+        $stored = $seo?->getTranslation('robots', App::getLocale(), false);
 
         $directives = is_array($stored) && $stored !== []
             ? array_values(array_filter($stored, 'is_string'))
@@ -236,18 +238,19 @@ trait HasSeo {
      * @param  array<string, string>  $vars
      * @return array<string, mixed>
      */
-    private function primarySchemaNode(SeoConfig $config, Seo $seo, array $vars): array {
-        $type = ($seo->schema_type ?? $config->schema_type)->schemaOrgType();
+    private function primarySchemaNode(SeoConfig $config, ?Seo $seo, array $vars): array {
+        $stored_type = $seo?->schema_type;
+        $type = ($stored_type ?? $config->schema_type)->schemaOrgType();
 
         // Per-property overrides for the current locale only (no fallback).
-        $stored = $seo->getTranslation('schema_overrides', App::getLocale(), false);
+        $stored = $seo?->getTranslation('schema_overrides', App::getLocale(), false);
         $overrides = is_array($stored) ? $stored : [];
 
         $node = ['@type' => $type];
 
         foreach ($config->schema as $property => $template) {
             $override = $overrides[$property] ?? null;
-            $value = $this->resolveTemplate(is_string($override) ? $override : $template, $vars);
+            $value = $this->substituteSeoVars(is_string($override) ? $override : $template, $vars);
 
             if ($value !== '') {
                 $node[$property] = $value;

--- a/app/Models/Concerns/HasSitemapTag.php
+++ b/app/Models/Concerns/HasSitemapTag.php
@@ -33,6 +33,10 @@ trait HasSitemapTag {
         $locales = $this->locales();
 
         foreach ($locales as $locale) {
+            if (method_exists($this, 'isIndexable') && ! $this->isIndexable($locale)) {
+                continue;
+            }
+
             $route = $this->getSitemapRoute($locale);
 
             /** @var Uri */
@@ -55,6 +59,10 @@ trait HasSitemapTag {
 
         foreach ($locales as $alternate) {
             if ($alternate === $current_locale) {
+                continue;
+            }
+
+            if (method_exists($this, 'isIndexable') && ! $this->isIndexable($alternate)) {
                 continue;
             }
 

--- a/app/Models/Concerns/HasSitemapTag.php
+++ b/app/Models/Concerns/HasSitemapTag.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Models\Concerns;
 
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Uri;
 use Spatie\Sitemap\Tags\Url;
 
 trait HasSitemapTag {
@@ -44,10 +43,7 @@ trait HasSitemapTag {
                 continue;
             }
 
-            /** @var Uri */
-            $uri = Route::localizedUrl($locale, $this->getSitemapRoute($locale));
-
-            $url = Url::create($uri->__toString())
+            $url = Url::create(Route::localizedUrlString($locale, $this->getSitemapRoute($locale)))
                 ->setPriority($this->getSitemapPriority())
                 ->setChangeFrequency($this->getSitemapChangeFrequency());
 
@@ -70,9 +66,7 @@ trait HasSitemapTag {
                 continue;
             }
 
-            /** @var Uri */
-            $uri = Route::localizedUrl($alternate, $this->getSitemapRoute($alternate));
-            $url->addAlternate($uri->__toString(), $alternate);
+            $url->addAlternate(Route::localizedUrlString($alternate, $this->getSitemapRoute($alternate)), $alternate);
         }
 
         return $url;

--- a/app/Models/Concerns/HasSitemapTag.php
+++ b/app/Models/Concerns/HasSitemapTag.php
@@ -27,42 +27,46 @@ trait HasSitemapTag {
             return '';
         }
 
-        $urls = [];
-
         /** @var list<string> $locales */
         $locales = $this->locales();
 
+        // Resolve indexability once per locale; both the main loop and the
+        // alternates reuse this map instead of re-checking each locale twice.
+        $indexable = [];
         foreach ($locales as $locale) {
-            if (method_exists($this, 'isIndexable') && ! $this->isIndexable($locale)) {
+            $indexable[$locale] = ! method_exists($this, 'isIndexable') || $this->isIndexable($locale);
+        }
+
+        $urls = [];
+
+        foreach ($locales as $locale) {
+            if (! $indexable[$locale]) {
                 continue;
             }
 
-            $route = $this->getSitemapRoute($locale);
-
             /** @var Uri */
-            $uri = Route::localizedUrl($locale, $route);
+            $uri = Route::localizedUrl($locale, $this->getSitemapRoute($locale));
 
             $url = Url::create($uri->__toString())
                 ->setPriority($this->getSitemapPriority())
                 ->setChangeFrequency($this->getSitemapChangeFrequency());
 
-            $url = $this->attachSitemapAlternates($url, $locale);
+            $url = $this->attachSitemapAlternates($url, $locale, $indexable);
             $urls[] = $url;
         }
 
         return $urls;
     }
 
-    private function attachSitemapAlternates(Url $url, string $current_locale): Url {
+    /**
+     * @param  array<string, bool>  $indexable  indexability per locale, resolved once by the caller
+     */
+    private function attachSitemapAlternates(Url $url, string $current_locale, array $indexable): Url {
         /** @var list<string> $locales */
         $locales = $this->locales();
 
         foreach ($locales as $alternate) {
-            if ($alternate === $current_locale) {
-                continue;
-            }
-
-            if (method_exists($this, 'isIndexable') && ! $this->isIndexable($alternate)) {
+            if ($alternate === $current_locale || ! $indexable[$alternate]) {
                 continue;
             }
 

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\DataTransferObjects\SeoConfig;
+use App\Enums\SchemaType;
 use App\Models\Concerns\HasRoutableSlug;
+use App\Models\Concerns\HasSeo;
 use App\Models\Concerns\HasSitemapTag;
 use App\Models\Concerns\LogsAllDirtyChanges;
 use App\Models\Concerns\ResolvesRoutBindingByLocalizedSlug;
@@ -41,10 +44,11 @@ use Spatie\Translatable\HasTranslations;
  * @property CarbonImmutable $updated_at
  * @property-read string $featured_image_url
  * @property-read string $short_description_or_excerpt
+ * @property-read Seo $seo
  */
 class Project extends Model implements HasMedia, LocalizedUrlRoutable, Sitemapable {
     /** @use HasFactory<ProjectFactory> */
-    use HasCurrentLocaleTranslationScope, HasFactory, HasRoutableSlug, HasSitemapTag, HasTags, HasTranslations, InteractsWithMedia, LogsAllDirtyChanges, ResolvesRoutBindingByLocalizedSlug;
+    use HasCurrentLocaleTranslationScope, HasFactory, HasRoutableSlug, HasSeo, HasSitemapTag, HasTags, HasTranslations, InteractsWithMedia, LogsAllDirtyChanges, ResolvesRoutBindingByLocalizedSlug;
 
     /** @var list<string> */
     public array $translatable = [
@@ -113,6 +117,46 @@ class Project extends Model implements HasMedia, LocalizedUrlRoutable, Sitemapab
         return $this->created_at->gt(now()->subDays(2))
             ? Url::CHANGE_FREQUENCY_DAILY
             : Url::CHANGE_FREQUENCY_MONTHLY;
+    }
+
+    protected function canAddToSitemap(): bool {
+        return $this->published;
+    }
+
+    public function seoDefaults(): SeoConfig {
+        return new SeoConfig(
+            schema_type: SchemaType::CREATIVE_WORK,
+            title: '{title} {title_separator} {site_name}',
+            description: '{excerpt}',
+            og_image: '{featured_image}',
+            schema: [
+                'name' => '{title}',
+                'description' => '{excerpt}',
+                'image' => '{featured_image}',
+                'dateCreated' => '{created_iso}',
+                'dateModified' => '{modified_iso}',
+                'inLanguage' => '{locale}',
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function seoVariables(): array {
+        return [
+            'title' => $this->title,
+            'excerpt' => $this->short_description_or_excerpt,
+            'client' => $this->client ?? '',
+            'tags' => $this->tags->pluck('name')->implode(', '),
+            'featured_image' => $this->featured_image_url,
+            'created_iso' => $this->created_at->toIso8601String(),
+            'modified_iso' => $this->updated_at->toIso8601String(),
+        ];
+    }
+
+    protected function isCrawlableByStatus(): bool {
+        return $this->published;
     }
 
     /** @return Attribute<string, never> */

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -44,7 +44,7 @@ use Spatie\Translatable\HasTranslations;
  * @property CarbonImmutable $updated_at
  * @property-read string $featured_image_url
  * @property-read string $short_description_or_excerpt
- * @property-read Seo $seo
+ * @property-read Seo|null $seo
  */
 class Project extends Model implements HasMedia, LocalizedUrlRoutable, Sitemapable {
     /** @use HasFactory<ProjectFactory> */

--- a/app/Models/Seo.php
+++ b/app/Models/Seo.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\SchemaType;
+use App\Enums\TwitterCard;
 use App\Models\Concerns\LogsAllDirtyChanges;
 use Carbon\CarbonImmutable;
 use Database\Factories\SeoFactory;
@@ -32,7 +33,7 @@ use Spatie\Translatable\HasTranslations;
  * @property list<string>|null $robots
  * @property array<string, mixed>|null $schema_overrides
  * @property SchemaType|null $schema_type
- * @property string|null $twitter_card
+ * @property TwitterCard|null $twitter_card
  * @property CarbonImmutable $created_at
  * @property CarbonImmutable $updated_at
  */
@@ -60,6 +61,7 @@ class Seo extends Model {
     protected function casts(): array {
         return [
             'schema_type' => SchemaType::class,
+            'twitter_card' => TwitterCard::class,
             'robots' => 'array',
             'schema_overrides' => 'array',
         ];

--- a/app/Models/Seo.php
+++ b/app/Models/Seo.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\SchemaType;
+use App\Models\Concerns\LogsAllDirtyChanges;
+use Carbon\CarbonImmutable;
+use Database\Factories\SeoFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Spatie\Translatable\HasTranslations;
+
+/**
+ * Per-record SEO overrides. Every column is nullable: a null value means
+ * "fall back to the model's default" (resolved by the HasSeo trait in Fase 3).
+ *
+ * @property int $id
+ * @property string $seoable_type
+ * @property int $seoable_id
+ * @property string|null $title
+ * @property string|null $description
+ * @property string|null $og_title
+ * @property string|null $og_description
+ * @property string|null $og_image
+ * @property string|null $twitter_title
+ * @property string|null $twitter_description
+ * @property string|null $twitter_image
+ * @property string|null $canonical
+ * @property list<string>|null $robots
+ * @property array<string, mixed>|null $schema_overrides
+ * @property SchemaType|null $schema_type
+ * @property string|null $twitter_card
+ * @property CarbonImmutable $created_at
+ * @property CarbonImmutable $updated_at
+ */
+class Seo extends Model {
+    /** @use HasFactory<SeoFactory> */
+    use HasFactory, HasTranslations, LogsAllDirtyChanges;
+
+    protected $table = 'seo';
+
+    /** @var list<string> */
+    public array $translatable = [
+        'title',
+        'description',
+        'og_title',
+        'og_description',
+        'og_image',
+        'twitter_title',
+        'twitter_description',
+        'twitter_image',
+        'canonical',
+        'robots',
+        'schema_overrides',
+    ];
+
+    protected function casts(): array {
+        return [
+            'schema_type' => SchemaType::class,
+            'robots' => 'array',
+            'schema_overrides' => 'array',
+        ];
+    }
+
+    /**
+     * @return MorphTo<Model, $this>
+     */
+    public function seoable(): MorphTo {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/SeoSetting.php
+++ b/app/Models/SeoSetting.php
@@ -10,7 +10,10 @@ use Carbon\CarbonImmutable;
 use Database\Factories\SeoSettingFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Uri;
 use Spatie\Translatable\HasTranslations;
 
 /**
@@ -68,5 +71,57 @@ class SeoSetting extends Model {
     protected static function booted(): void {
         static::saved(fn () => Cache::forget(self::CACHE_KEY));
         static::deleted(fn () => Cache::forget(self::CACHE_KEY));
+    }
+
+    /**
+     * Sitewide schema.org nodes for the JSON-LD @graph: the WebSite (when
+     * enabled) and the site identity (Person or Organization). Prepended to
+     * every page's @graph so crawlers always see the site's identity.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function schemaNodes(): array {
+        $name = $this->name ?? config()->string('app.name');
+        $url = $this->homeUrl();
+
+        $nodes = [];
+
+        if ($this->website_schema) {
+            $nodes[] = [
+                '@type' => SchemaType::WEB_SITE->schemaOrgType(),
+                'name' => $name,
+                'url' => $url,
+                'inLanguage' => App::getLocale(),
+            ];
+        }
+
+        $identity = [
+            '@type' => $this->type->schemaOrgType(),
+            'name' => $name,
+            'url' => $url,
+        ];
+
+        if ($this->description !== null && $this->description !== '') {
+            $identity['description'] = $this->description;
+        }
+
+        if ($this->default_og_image !== null && $this->default_og_image !== '') {
+            $identity['image'] = $this->default_og_image;
+        }
+
+        if ($this->social_profiles !== null && $this->social_profiles !== []) {
+            $identity['sameAs'] = $this->social_profiles;
+        }
+
+        $nodes[] = $identity;
+
+        return $nodes;
+    }
+
+    private function homeUrl(): string {
+        /** @var Uri $uri */
+        $uri = Route::localizedUrl(App::getLocale(), route('home'));
+
+        return $uri->__toString();
     }
 }

--- a/app/Models/SeoSetting.php
+++ b/app/Models/SeoSetting.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Uri;
 use Spatie\Translatable\HasTranslations;
 
 /**
@@ -119,9 +118,6 @@ class SeoSetting extends Model {
     }
 
     private function homeUrl(): string {
-        /** @var Uri $uri */
-        $uri = Route::localizedUrl(App::getLocale(), route('home'));
-
-        return $uri->__toString();
+        return Route::localizedUrlString(App::getLocale(), route('home'));
     }
 }

--- a/app/Models/SeoSetting.php
+++ b/app/Models/SeoSetting.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\SchemaType;
+use App\Models\Concerns\LogsAllDirtyChanges;
+use Carbon\CarbonImmutable;
+use Database\Factories\SeoSettingFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
+use Spatie\Translatable\HasTranslations;
+
+/**
+ * Site-wide SEO identity and defaults — a single-row settings record.
+ *
+ * @property int $id
+ * @property SchemaType $type
+ * @property string|null $name
+ * @property string|null $description
+ * @property list<string>|null $social_profiles
+ * @property string|null $default_og_image
+ * @property string $title_separator
+ * @property bool $website_schema
+ * @property CarbonImmutable $created_at
+ * @property CarbonImmutable $updated_at
+ */
+class SeoSetting extends Model {
+    /** @use HasFactory<SeoSettingFactory> */
+    use HasFactory, HasTranslations, LogsAllDirtyChanges;
+
+    private const string CACHE_KEY = 'seo_settings';
+
+    /** @var list<string> */
+    public array $translatable = ['description'];
+
+    /**
+     * Defaults live here (mirrored from no DB defaults), so the singleton works
+     * with sensible values before anything is persisted.
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'type' => SchemaType::PERSON->value,
+        'title_separator' => ' | ',
+        'website_schema' => true,
+    ];
+
+    protected function casts(): array {
+        return [
+            'type' => SchemaType::class,
+            'social_profiles' => 'array',
+            'website_schema' => 'boolean',
+        ];
+    }
+
+    /**
+     * The single settings row, cached forever (invalidated on save/delete).
+     * Falls back to an unsaved instance carrying the default attributes, so the
+     * application has working settings before the row is created in Filament.
+     */
+    public static function current(): self {
+        return Cache::rememberForever(self::CACHE_KEY, fn (): self => self::query()->firstOrNew());
+    }
+
+    protected static function booted(): void {
+        static::saved(fn () => Cache::forget(self::CACHE_KEY));
+        static::deleted(fn () => Cache::forget(self::CACHE_KEY));
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ */
 class User extends Authenticatable implements FilamentUser {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -83,20 +83,31 @@ class AppServiceProvider extends ServiceProvider {
 
         App::macro('supportedLocales', fn (): array => LaravelLocalization::getSupportedLocales());
 
-        Route::macro('localizedUrl',
-            function (
+        $localizedUri = function (
+            string|bool|null $locale = null,
+            string|false|null $url = null,
+            array $attributes = [],
+            bool $force_default_location = false
+        ): Uri {
+            try {
+                return Uri::of((string) LaravelLocalization::getLocalizedURL($locale, $url, $attributes, $force_default_location))
+                    ->withoutQuery(['missing_translations']);
+            } catch (MissingRoutableLocalizedRouteKeyException) {
+                return Uri::of(request()->url())->withQuery(['missing_translations' => $locale]);
+            }
+        };
+
+        Route::macro('localizedUrl', $localizedUri);
+
+        // Same as localizedUrl(), but returns the URL already cast to a string —
+        // saves callers the `->__toString()` (and the @var Uri hint larastan needs).
+        Route::macro('localizedUrlString',
+            fn (
                 string|bool|null $locale = null,
                 string|false|null $url = null,
                 array $attributes = [],
                 bool $force_default_location = false
-            ) {
-                try {
-                    return Uri::of((string) LaravelLocalization::getLocalizedURL($locale, $url, $attributes, $force_default_location))
-                        ->withoutQuery(['missing_translations']);
-                } catch (MissingRoutableLocalizedRouteKeyException) {
-                    return Uri::of(request()->url())->withQuery(['missing_translations' => $locale]);
-                }
-            }
+            ): string => $localizedUri($locale, $url, $attributes, $force_default_location)->__toString()
         );
 
         Route::macro('livewireLocalized',

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -15,6 +15,7 @@ use App\Macros\Request\CookieStringOrDefaultMacro;
 use App\Macros\Request\QueryStringOrDefaultMacro;
 use App\Macros\Request\QueryStringOrNullMacro;
 use App\Macros\Str\ReplacePlaceholdersMacro;
+use App\View\Composers\SeoComposer;
 use Carbon\CarbonImmutable;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\DateTimePicker;
@@ -30,6 +31,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Sleep;
@@ -124,6 +126,8 @@ class AppServiceProvider extends ServiceProvider {
         });
 
         Str::macro(...ReplacePlaceholdersMacro::register());
+
+        View::composer(['layouts::public.index', 'layouts.public.index'], SeoComposer::class);
 
         collect([
             QueryStringOrDefaultMacro::class,

--- a/app/View/Composers/SeoComposer.php
+++ b/app/View/Composers/SeoComposer.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\View\Composers;
+
+use App\DataTransferObjects\SeoData;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Uri;
+use Illuminate\View\View;
+
+/**
+ * Provides the public layout with a default `$seo_data` (title, canonical and
+ * hreflang alternates) when a page has not supplied its own resolved SeoData.
+ * Richer, per-model SeoData is injected by pages and short-circuits this default.
+ */
+class SeoComposer {
+    public function compose(View $view): void {
+        $data = $view->getData();
+
+        // A page (or a later phase) may already provide its own resolved SeoData.
+        if (isset($data['seo_data'])) {
+            return;
+        }
+
+        $view->with('seo_data', new SeoData(
+            title: $this->title($data),
+            canonical: url()->current(),
+            alternates: $this->alternates(),
+        ));
+    }
+
+    /**
+     * Mirrors the layout's previous title logic: append the app name unless a
+     * `suffix` was provided, in which case use it (or omit it entirely on false).
+     *
+     * @param  array<array-key, mixed>  $data
+     */
+    private function title(array $data): string {
+        $separator = $this->separator();
+        $app_name = config()->string('app.name');
+        $title = isset($data['title']) && is_string($data['title']) && $data['title'] !== ''
+            ? $data['title']
+            : $app_name;
+
+        if (! isset($data['suffix'])) {
+            return $title.$separator.$app_name;
+        }
+
+        return is_string($data['suffix'])
+            ? $title.$separator.$data['suffix']
+            : $title;
+    }
+
+    /**
+     * Title separator. Fase 2 will source this from the cached global
+     * `SeoSetting::current()->title_separator` (cached, so no per-request DB hit).
+     */
+    private function separator(): string {
+        return ' | ';
+    }
+
+    /**
+     * One hreflang alternate per supported locale, pointing at the current page
+     * in that locale — identical to the layout's previous alternates loop.
+     *
+     * @return list<array{hreflang: string, href: string}>
+     */
+    private function alternates(): array {
+        $alternates = [];
+
+        foreach (array_keys(App::supportedLocales()) as $locale) {
+            /** @var Uri $uri */
+            $uri = Route::localizedUrl(locale: $locale, force_default_location: true);
+
+            $alternates[] = [
+                'hreflang' => $locale,
+                'href' => $uri->__toString(),
+            ];
+        }
+
+        return $alternates;
+    }
+}

--- a/app/View/Composers/SeoComposer.php
+++ b/app/View/Composers/SeoComposer.php
@@ -8,7 +8,6 @@ use App\DataTransferObjects\SeoData;
 use App\Models\SeoSetting;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Uri;
 use Illuminate\View\View;
 
 /**
@@ -74,12 +73,9 @@ class SeoComposer {
         $alternates = [];
 
         foreach (array_keys(App::supportedLocales()) as $locale) {
-            /** @var Uri $uri */
-            $uri = Route::localizedUrl(locale: $locale, force_default_location: true);
-
             $alternates[] = [
                 'hreflang' => $locale,
-                'href' => $uri->__toString(),
+                'href' => Route::localizedUrlString(locale: $locale, force_default_location: true),
             ];
         }
 

--- a/app/View/Composers/SeoComposer.php
+++ b/app/View/Composers/SeoComposer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Composers;
 
 use App\DataTransferObjects\SeoData;
+use App\Models\SeoSetting;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Uri;
@@ -54,11 +55,10 @@ class SeoComposer {
     }
 
     /**
-     * Title separator. Fase 2 will source this from the cached global
-     * `SeoSetting::current()->title_separator` (cached, so no per-request DB hit).
+     * Title separator, from the cached global settings (no per-request DB hit).
      */
     private function separator(): string {
-        return ' | ';
+        return SeoSetting::current()->title_separator;
     }
 
     /**

--- a/app/View/Composers/SeoComposer.php
+++ b/app/View/Composers/SeoComposer.php
@@ -20,16 +20,19 @@ class SeoComposer {
     public function compose(View $view): void {
         $data = $view->getData();
 
-        // A page (or a later phase) may already provide its own resolved SeoData.
-        if (isset($data['seo_data'])) {
-            return;
-        }
+        // A page may supply its own resolved SeoData (show pages do); otherwise
+        // fall back to a minimal default built from the page title.
+        $seo_data = isset($data['seo_data']) && $data['seo_data'] instanceof SeoData
+            ? $data['seo_data']
+            : new SeoData(
+                title: $this->title($data),
+                canonical: url()->current(),
+                alternates: $this->alternates(),
+            );
 
-        $view->with('seo_data', new SeoData(
-            title: $this->title($data),
-            canonical: url()->current(),
-            alternates: $this->alternates(),
-        ));
+        // The sitewide identity (WebSite + Person/Organization) is prepended to
+        // every page's @graph, whether the SeoData is page-provided or default.
+        $view->with('seo_data', $seo_data->prependJsonLd(SeoSetting::current()->schemaNodes()));
     }
 
     /**

--- a/database/factories/SeoFactory.php
+++ b/database/factories/SeoFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\SchemaType;
+use App\Models\BlogArticle;
+use App\Models\Seo;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Seo>
+ */
+class SeoFactory extends Factory {
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array {
+        return [
+            'seoable_id' => BlogArticle::factory(),
+            'seoable_type' => (new BlogArticle)->getMorphClass(),
+            'title' => [
+                'it' => fake('it')->sentence(),
+                'en' => fake('en')->sentence(),
+            ],
+            'description' => [
+                'it' => fake('it')->sentence(),
+                'en' => fake('en')->sentence(),
+            ],
+            'schema_type' => SchemaType::ARTICLE,
+        ];
+    }
+}

--- a/database/factories/SeoSettingFactory.php
+++ b/database/factories/SeoSettingFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\SchemaType;
+use App\Models\SeoSetting;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SeoSetting>
+ */
+class SeoSettingFactory extends Factory {
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array {
+        return [
+            'type' => SchemaType::PERSON,
+            'name' => fake()->name(),
+            'description' => [
+                'it' => fake('it')->sentence(),
+                'en' => fake('en')->sentence(),
+            ],
+            'social_profiles' => [fake()->url(), fake()->url()],
+            'default_og_image' => null,
+            'title_separator' => ' | ',
+            'website_schema' => true,
+        ];
+    }
+}

--- a/database/migrations/2026_05_30_164004_create_seo_settings_table.php
+++ b/database/migrations/2026_05_30_164004_create_seo_settings_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::create('seo_settings', function (Blueprint $table) {
+            $table->id();
+
+            $table->string('type');
+            $table->string('name')->nullable();
+            $table->json('description')->nullable();
+            $table->json('social_profiles')->nullable();
+            $table->string('default_og_image')->nullable();
+            $table->string('title_separator');
+            $table->boolean('website_schema');
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::dropIfExists('seo_settings');
+    }
+};

--- a/database/migrations/2026_05_30_164004_create_seo_table.php
+++ b/database/migrations/2026_05_30_164004_create_seo_table.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::create('seo', function (Blueprint $table) {
+            $table->id();
+
+            $table->morphs('seoable');
+            $table->unique(['seoable_type', 'seoable_id']);
+
+            // Translatable. If null fall back to the model default.
+            $table->json('title')->nullable();
+            $table->json('description')->nullable();
+            $table->json('og_title')->nullable();
+            $table->json('og_description')->nullable();
+            $table->json('og_image')->nullable();
+            $table->json('twitter_title')->nullable();
+            $table->json('twitter_description')->nullable();
+            $table->json('twitter_image')->nullable();
+            $table->json('canonical')->nullable();
+            $table->json('robots')->nullable();
+            $table->json('schema_overrides')->nullable();
+
+            // Non-translatable.
+            $table->string('schema_type')->nullable();
+            $table->string('twitter_card')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::dropIfExists('seo');
+    }
+};

--- a/resources/views/filament/pages/seo-settings.blade.php
+++ b/resources/views/filament/pages/seo-settings.blade.php
@@ -1,0 +1,3 @@
+<x-filament::page>
+    {{ $this->form }}
+</x-filament::page>

--- a/resources/views/layouts/public/index.blade.php
+++ b/resources/views/layouts/public/index.blade.php
@@ -14,21 +14,7 @@
     <meta name="apple-mobile-web-app-title" content="{{ config('app.name') }}" />
     <link rel="manifest" href="/favicon/site.webmanifest" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
-    <title>
-        {{ __($title) }}
-
-        @if (!isset($suffix))
-            |&nbsp;{{ config('app.name') }}
-        @elseif ($suffix !== false)
-            |&nbsp;{{ __($suffix) }}
-        @endif
-    </title>
-
-    <link rel="canonical" href="{{ url()->current() }}">
-    @foreach (app()->supportedLocales() as $locale => $props)
-        <link rel="alternate" hreflang="{{ $locale }}"
-            href="{{ Route::localizedUrl(locale: $locale, force_default_location: true) }}">
-    @endforeach
+    @include('layouts.public.seo', ['seo_data' => $seo_data ?? null])
 
     @stack('seo')
 

--- a/resources/views/layouts/public/seo.blade.php
+++ b/resources/views/layouts/public/seo.blade.php
@@ -1,0 +1,36 @@
+{{-- Renders the resolved SEO metadata. Only the sections present on $seo_data are emitted. --}}
+@php
+    /** @var \App\DataTransferObjects\SeoData|null $seo_data */
+@endphp
+@if ($seo_data)
+    {{-- A page must always carry a title: fall back to the app name when none was resolved. --}}
+    <title>{{ $seo_data->title ?: config('app.name') }}</title>
+
+    @if ($seo_data->description)
+        <meta name="description" content="{{ $seo_data->description }}">
+    @endif
+
+    @if ($seo_data->robots)
+        <meta name="robots" content="{{ $seo_data->robots }}">
+    @endif
+
+    @if ($seo_data->canonical)
+        <link rel="canonical" href="{{ $seo_data->canonical }}">
+    @endif
+
+    @foreach ($seo_data->alternates as $alternate)
+        <link rel="alternate" hreflang="{{ $alternate['hreflang'] }}" href="{{ $alternate['href'] }}">
+    @endforeach
+
+    @foreach ($seo_data->open_graph as $property => $content)
+        <meta property="{{ $property }}" content="{{ $content }}">
+    @endforeach
+
+    @foreach ($seo_data->twitter as $name => $content)
+        <meta name="{{ $name }}" content="{{ $content }}">
+    @endforeach
+
+    @foreach ($seo_data->json_ld as $schema)
+        <script type="application/ld+json">{!! \Safe\json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}</script>
+    @endforeach
+@endif

--- a/resources/views/layouts/public/seo.blade.php
+++ b/resources/views/layouts/public/seo.blade.php
@@ -30,7 +30,8 @@
         <meta name="{{ $name }}" content="{{ $content }}">
     @endforeach
 
-    @foreach ($seo_data->json_ld as $schema)
-        <script type="application/ld+json">{!! \Safe\json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}</script>
-    @endforeach
+    @if ($seo_data->json_ld)
+        {{-- @@context is escaped to a literal "@context" so Blade doesn't treat it as a directive. --}}
+        <script type="application/ld+json">{!! \Safe\json_encode(['@@context' => 'https://schema.org', '@graph' => $seo_data->json_ld], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) !!}</script>
+    @endif
 @endif

--- a/tests/Feature/Filament/BlogArticleResourceTest.php
+++ b/tests/Feature/Filament/BlogArticleResourceTest.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 use App\Enums\BlogArticleStatuses;
+use App\Enums\RobotsDirective;
+use App\Enums\SchemaType;
+use App\Enums\TwitterCard;
 use App\Filament\Resources\BlogArticles\Pages\CreateBlogArticle;
 use App\Filament\Resources\BlogArticles\Pages\EditBlogArticle;
 use App\Filament\Resources\BlogArticles\Pages\ListBlogArticles;
@@ -62,6 +65,47 @@ it('validates the required fields on create', function () {
         ])
         ->call('create')
         ->assertHasFormErrors(['title', 'slug', 'summary', 'content', 'status']);
+});
+
+describe('SEO overrides', function () {
+    it('saves translatable SEO overrides to the active locale, preserving the other', function () {
+        $article = BlogArticle::factory()->create();
+
+        $component = livewire(EditBlogArticle::class, ['record' => $article->id]);
+
+        $component->fillForm(['seo.title' => 'Titolo SEO'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $component->call('setActiveLocale', 'en')
+            ->fillForm(['seo.title' => 'SEO Title'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $article->refresh()->load('seo');
+
+        expect($article->seo->getTranslation('title', 'it', false))->toBe('Titolo SEO')
+            ->and($article->seo->getTranslation('title', 'en', false))->toBe('SEO Title');
+    });
+
+    it('persists the non-translatable enum fields and robots directives', function () {
+        $article = BlogArticle::factory()->create();
+
+        livewire(EditBlogArticle::class, ['record' => $article->id])
+            ->fillForm([
+                'seo.schema_type' => SchemaType::ARTICLE->value,
+                'seo.twitter_card' => TwitterCard::SUMMARY->value,
+                'seo.robots' => [RobotsDirective::NOINDEX->value, RobotsDirective::NOFOLLOW->value],
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $article->refresh()->load('seo');
+
+        expect($article->seo->schema_type)->toBe(SchemaType::ARTICLE)
+            ->and($article->seo->twitter_card)->toBe(TwitterCard::SUMMARY)
+            ->and($article->seo->robots)->toBe([RobotsDirective::NOINDEX->value, RobotsDirective::NOFOLLOW->value]);
+    });
 });
 
 describe('published_at stamping (regression for the ?? precedence bug)', function () {

--- a/tests/Feature/Filament/BlogArticleResourceTest.php
+++ b/tests/Feature/Filament/BlogArticleResourceTest.php
@@ -10,6 +10,7 @@ use App\Filament\Resources\BlogArticles\Pages\CreateBlogArticle;
 use App\Filament\Resources\BlogArticles\Pages\EditBlogArticle;
 use App\Filament\Resources\BlogArticles\Pages\ListBlogArticles;
 use App\Models\BlogArticle;
+use App\Models\Seo;
 
 use function Pest\Livewire\livewire;
 
@@ -86,6 +87,33 @@ describe('SEO overrides', function () {
 
         expect($article->seo->getTranslation('title', 'it', false))->toBe('Titolo SEO')
             ->and($article->seo->getTranslation('title', 'en', false))->toBe('SEO Title');
+    });
+
+    it('creates no Seo row when the section is left blank', function () {
+        $article = BlogArticle::factory()->create();
+
+        livewire(EditBlogArticle::class, ['record' => $article->id])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        expect(Seo::query()->where('seoable_id', $article->id)->exists())->toBeFalse();
+    });
+
+    it('prunes the Seo row once every override is cleared', function () {
+        $article = BlogArticle::factory()->create();
+        // A row whose only override is the title, so clearing it empties the record.
+        Seo::factory()->for($article, 'seoable')->create([
+            'title' => ['it' => 'Temporaneo'],
+            'description' => null,
+            'schema_type' => null,
+        ]);
+
+        livewire(EditBlogArticle::class, ['record' => $article->id])
+            ->fillForm(['seo.title' => null])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        expect(Seo::query()->where('seoable_id', $article->id)->exists())->toBeFalse();
     });
 
     it('persists the non-translatable enum fields and robots directives', function () {

--- a/tests/Feature/Filament/ProjectResourceTest.php
+++ b/tests/Feature/Filament/ProjectResourceTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Enums\SchemaType;
 use App\Filament\Resources\Projects\Pages\CreateProject;
+use App\Filament\Resources\Projects\Pages\EditProject;
 use App\Filament\Resources\Projects\Pages\ListProjects;
 use App\Models\Project;
 
@@ -30,6 +32,27 @@ it('creates a project', function () {
         ->assertHasNoFormErrors();
 
     expect(Project::query()->count())->toBe(1);
+});
+
+it('saves SEO overrides for a project per locale', function () {
+    $project = Project::factory()->create();
+
+    $component = livewire(EditProject::class, ['record' => $project->id]);
+
+    $component->fillForm([
+        'seo.title' => 'Titolo Progetto',
+        'seo.schema_type' => SchemaType::PRODUCT->value,
+    ])->call('save')->assertHasNoFormErrors();
+
+    $component->call('setActiveLocale', 'en')
+        ->fillForm(['seo.title' => 'Project Title'])
+        ->call('save')->assertHasNoFormErrors();
+
+    $project->refresh()->load('seo');
+
+    expect($project->seo->getTranslation('title', 'it', false))->toBe('Titolo Progetto')
+        ->and($project->seo->getTranslation('title', 'en', false))->toBe('Project Title')
+        ->and($project->seo->schema_type)->toBe(SchemaType::PRODUCT);
 });
 
 describe('slug uniqueness (regression: uniqueness must check the slug column, not title)', function () {

--- a/tests/Feature/Filament/SeoSettingsPageTest.php
+++ b/tests/Feature/Filament/SeoSettingsPageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SchemaType;
+use App\Filament\Pages\SeoSettings;
+use App\Models\SeoSetting;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    $this->withoutVite();
+    actingAsAdmin();
+});
+
+it('renders the settings page', function () {
+    livewire(SeoSettings::class)->assertOk();
+});
+
+it('saves the SEO settings singleton with a per-locale description', function () {
+    livewire(SeoSettings::class)
+        ->fillForm([
+            'type' => SchemaType::ORGANIZATION->value,
+            'name' => 'Acme Inc',
+            'description' => ['en' => 'We build things', 'it' => 'Costruiamo cose'],
+            'social_profiles' => [['url' => 'https://twitter.com/acme']],
+            'website_schema' => true,
+            'default_og_image' => 'https://example.test/og.jpg',
+            'title_separator' => ' - ',
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $setting = SeoSetting::query()->firstOrFail();
+
+    expect($setting->type)->toBe(SchemaType::ORGANIZATION)
+        ->and($setting->name)->toBe('Acme Inc')
+        ->and($setting->getTranslation('description', 'en', false))->toBe('We build things')
+        ->and($setting->getTranslation('description', 'it', false))->toBe('Costruiamo cose')
+        ->and($setting->social_profiles)->toBe(['https://twitter.com/acme'])
+        ->and($setting->website_schema)->toBeTrue()
+        ->and($setting->title_separator)->toBe(' - ');
+});

--- a/tests/Feature/Livewire/Pages/BlogArticleShowTest.php
+++ b/tests/Feature/Livewire/Pages/BlogArticleShowTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use App\Livewire\Pages\BlogArticle\BlogArticleShow;
 use App\Models\BlogArticle;
+use Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRedirectFilter;
+use Mcamara\LaravelLocalization\Middleware\LocaleSessionRedirect;
 
 use function Pest\Livewire\livewire;
 
@@ -16,6 +18,28 @@ it('renders a blog article', function () {
         ->assertOk();
 
     expect($component->instance()->blog_article->id)->toBe($article->id);
+});
+
+it('renders the full SEO head, including the sitewide schema nodes', function () {
+    $article = BlogArticle::factory()->published()->create(['title' => 'My SEO Article']);
+    $url = route('blog_article.show', $article->getTranslation('slug', app()->getLocale()));
+
+    $html = $this->withoutMiddleware([
+        LaravelLocalizationRedirectFilter::class,
+        LocaleSessionRedirect::class,
+    ])->get($url)->assertOk()->getContent();
+
+    expect($html)
+        ->toContain('<title>My SEO Article | '.config('app.name').'</title>')
+        ->toContain('<meta name="description"')
+        ->toContain('<link rel="canonical"')
+        ->toContain('property="og:title"')
+        ->toContain('name="twitter:card"')
+        // The page node and the prepended sitewide nodes share one @graph.
+        ->toContain('"@type":"BlogPosting"')
+        ->toContain('"@type":"WebSite"')
+        ->and(substr_count((string) $html, '<title'))->toBe(1)
+        ->and(substr_count((string) $html, 'application/ld+json'))->toBe(1);
 });
 
 it('exposes previous and next published articles', function () {

--- a/tests/Feature/Livewire/Pages/ProjectShowTest.php
+++ b/tests/Feature/Livewire/Pages/ProjectShowTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use App\Livewire\Pages\Project\ProjectShow;
 use App\Models\Project;
+use Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRedirectFilter;
+use Mcamara\LaravelLocalization\Middleware\LocaleSessionRedirect;
 
 use function Pest\Livewire\livewire;
 
@@ -16,4 +18,25 @@ it('renders a project', function () {
         ->assertOk();
 
     expect($component->instance()->project->id)->toBe($project->id);
+});
+
+it('renders the full SEO head, including the sitewide schema nodes', function () {
+    $project = Project::factory()->published()->create(['title' => 'My SEO Project']);
+    $url = route('project.show', $project->getTranslation('slug', app()->getLocale()));
+
+    $html = $this->withoutMiddleware([
+        LaravelLocalizationRedirectFilter::class,
+        LocaleSessionRedirect::class,
+    ])->get($url)->assertOk()->getContent();
+
+    expect($html)
+        ->toContain('<title>My SEO Project | '.config('app.name').'</title>')
+        ->toContain('<link rel="canonical"')
+        ->toContain('property="og:title"')
+        ->toContain('name="twitter:card"')
+        // The page node and the prepended sitewide nodes share one @graph.
+        ->toContain('"@type":"CreativeWork"')
+        ->toContain('"@type":"WebSite"')
+        ->and(substr_count((string) $html, '<title'))->toBe(1)
+        ->and(substr_count((string) $html, 'application/ld+json'))->toBe(1);
 });

--- a/tests/Feature/Models/Concerns/HasSeoTest.php
+++ b/tests/Feature/Models/Concerns/HasSeoTest.php
@@ -6,6 +6,7 @@ use App\Enums\RobotsDirective;
 use App\Models\BlogArticle;
 use App\Models\Project;
 use App\Models\Seo;
+use App\Models\SeoSetting;
 
 it('resolves SeoData from the model defaults', function () {
     $article = BlogArticle::factory()->create([
@@ -92,4 +93,45 @@ it('honours a stored per-locale noindex override', function () {
     expect(withLocale('en', fn () => $article->toSeoData()->robots))->toContain('noindex')
         ->and($article->isIndexable('en'))->toBeFalse()
         ->and($article->isIndexable('it'))->toBeTrue();
+});
+
+it('does not leak a single-locale override into another locale', function () {
+    $article = BlogArticle::factory()->create([
+        'title' => ['en' => 'EN Title', 'it' => 'Titolo IT'],
+    ]);
+
+    // Override stored only for EN.
+    Seo::factory()->for($article, 'seoable')->create(['title' => ['en' => 'Custom EN Override']]);
+    $article->load('seo');
+
+    $en = withLocale('en', fn () => $article->toSeoData()->title);
+    $it = withLocale('it', fn () => $article->toSeoData()->title);
+
+    expect($en)->toBe('Custom EN Override')
+        // IT has no override → it falls through to the model's default template,
+        // NOT the EN override (no spatie fallback leak).
+        ->and($it)->toContain('Titolo IT')
+        ->and($it)->not->toContain('Custom EN Override');
+});
+
+it('honours a per-locale robots override without leaking to other locales', function () {
+    $article = BlogArticle::factory()->create();
+
+    Seo::factory()->for($article, 'seoable')->create([
+        'robots' => ['en' => [RobotsDirective::NOINDEX->value], 'it' => []],
+    ]);
+    $article->load('seo');
+
+    expect(withLocale('en', fn () => $article->toSeoData()->robots))->toContain('noindex')
+        ->and(withLocale('it', fn () => $article->toSeoData()->robots))->toBeNull();
+});
+
+it('uses the SeoSetting name for {site_name} and og:site_name', function () {
+    SeoSetting::factory()->create(['name' => 'Acme Studio']);
+
+    $article = BlogArticle::factory()->create(['title' => ['en' => 'Hello', 'it' => 'Ciao']]);
+    $seo = withLocale('en', fn () => $article->toSeoData());
+
+    expect($seo->title)->toContain('Acme Studio')
+        ->and($seo->open_graph['og:site_name'])->toBe('Acme Studio');
 });

--- a/tests/Feature/Models/Concerns/HasSeoTest.php
+++ b/tests/Feature/Models/Concerns/HasSeoTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\RobotsDirective;
+use App\Models\BlogArticle;
+use App\Models\Project;
+use App\Models\Seo;
+
+it('resolves SeoData from the model defaults', function () {
+    $article = BlogArticle::factory()->create([
+        'title' => ['en' => 'Hello World', 'it' => 'Ciao Mondo'],
+        'summary' => ['en' => 'An English summary', 'it' => 'Un riassunto'],
+    ]);
+
+    $seo = withLocale('en', fn () => $article->toSeoData());
+
+    expect($seo->title)->toContain('Hello World')->toContain(config('app.name'))
+        ->and($seo->description)->toBe('An English summary')
+        ->and($seo->canonical)->not->toBeEmpty()
+        ->and($seo->robots)->toBeNull()
+        ->and($seo->open_graph['og:title'])->toContain('Hello World')
+        ->and($seo->open_graph['og:type'])->toBe('article')
+        ->and($seo->twitter['twitter:card'])->toBe('summary_large_image')
+        ->and($seo->json_ld[0]['@type'])->toBe('BlogPosting')
+        ->and($seo->json_ld[0]['headline'])->toBe('Hello World')
+        ->and($seo->json_ld[0])->toHaveKey('datePublished');
+});
+
+it('lets stored SEO overrides take precedence over the defaults', function () {
+    $article = BlogArticle::factory()->create(['title' => ['en' => 'Original', 'it' => 'Originale']]);
+
+    Seo::factory()->for($article, 'seoable')->create([
+        'title' => ['en' => 'Custom SEO Title', 'it' => 'Titolo SEO'],
+    ]);
+    $article->load('seo');
+
+    expect(withLocale('en', fn () => $article->toSeoData()->title))->toBe('Custom SEO Title')
+        ->and(withLocale('it', fn () => $article->toSeoData()->title))->toBe('Titolo SEO');
+});
+
+it('resolves SeoData in the requested locale', function () {
+    $article = BlogArticle::factory()->create([
+        'title' => ['en' => 'Hello', 'it' => 'Ciao'],
+        'summary' => ['en' => 'EN summary', 'it' => 'IT riassunto'],
+    ]);
+
+    $seo = withLocale('it', fn () => $article->toSeoData());
+
+    expect($seo->title)->toContain('Ciao')
+        ->and($seo->description)->toBe('IT riassunto')
+        ->and($seo->open_graph['og:locale'])->toBe('it_IT');
+});
+
+it('resolves a CreativeWork node for a project', function () {
+    $project = Project::factory()->create([
+        'title' => ['en' => 'My Project', 'it' => 'Mio Progetto'],
+        'short_description' => ['en' => 'A great project', 'it' => 'Un bel progetto'],
+        'published' => true,
+    ]);
+
+    $seo = withLocale('en', fn () => $project->toSeoData());
+
+    expect($seo->json_ld[0]['@type'])->toBe('CreativeWork')
+        ->and($seo->json_ld[0]['name'])->toBe('My Project')
+        ->and($seo->description)->toBe('A great project')
+        ->and($seo->json_ld[0])->toHaveKey('dateCreated');
+});
+
+it('includes one hreflang alternate per translated locale', function () {
+    $article = BlogArticle::factory()->create();
+
+    expect(collect($article->toSeoData()->alternates)->pluck('hreflang')->all())
+        ->toContain('en', 'it');
+});
+
+it('marks a non-crawlable article as noindex', function () {
+    $article = BlogArticle::factory()->draft()->create();
+
+    expect($article->toSeoData()->robots)->toContain('noindex')
+        ->and($article->isIndexable())->toBeFalse();
+});
+
+it('honours a stored per-locale noindex override', function () {
+    $article = BlogArticle::factory()->create();
+
+    Seo::factory()->for($article, 'seoable')->create([
+        'robots' => ['en' => [RobotsDirective::NOINDEX->value], 'it' => []],
+    ]);
+    $article->load('seo');
+
+    expect(withLocale('en', fn () => $article->toSeoData()->robots))->toContain('noindex')
+        ->and($article->isIndexable('en'))->toBeFalse()
+        ->and($article->isIndexable('it'))->toBeTrue();
+});

--- a/tests/Feature/Models/SeoSettingTest.php
+++ b/tests/Feature/Models/SeoSettingTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SchemaType;
+use App\Models\SeoSetting;
+
+it('provides a default unsaved singleton when none exists', function () {
+    $settings = SeoSetting::current();
+
+    expect($settings->exists)->toBeFalse()
+        ->and($settings->type)->toBe(SchemaType::PERSON)
+        ->and($settings->title_separator)->toBe(' | ')
+        ->and($settings->website_schema)->toBeTrue();
+});
+
+it('returns the persisted singleton once saved', function () {
+    SeoSetting::factory()->create(['title_separator' => ' — ']);
+
+    expect(SeoSetting::current()->exists)->toBeTrue()
+        ->and(SeoSetting::current()->title_separator)->toBe(' — ');
+});
+
+it('invalidates the cached singleton when settings are saved', function () {
+    // Prime the cache with the default (no row yet).
+    expect(SeoSetting::current()->title_separator)->toBe(' | ');
+
+    SeoSetting::factory()->create(['title_separator' => ' · ']);
+
+    expect(SeoSetting::current()->title_separator)->toBe(' · ');
+});
+
+it('stores the description translatably and casts json columns', function () {
+    $settings = SeoSetting::factory()->create([
+        'description' => ['en' => 'Bio', 'it' => 'Biografia'],
+        'social_profiles' => ['https://example.test/a', 'https://example.test/b'],
+        'website_schema' => false,
+    ]);
+
+    $settings->refresh();
+
+    expect($settings->getTranslation('description', 'it'))->toBe('Biografia')
+        ->and($settings->social_profiles)->toBe(['https://example.test/a', 'https://example.test/b'])
+        ->and($settings->website_schema)->toBeFalse();
+});

--- a/tests/Feature/Models/SeoTest.php
+++ b/tests/Feature/Models/SeoTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SchemaType;
+use App\Models\BlogArticle;
+use App\Models\Seo;
+use Illuminate\Database\QueryException;
+
+it('stores and retrieves translatable fields per locale', function () {
+    $seo = Seo::factory()->create([
+        'title' => ['en' => 'English title', 'it' => 'Titolo italiano'],
+    ]);
+
+    $seo->refresh();
+
+    expect($seo->getTranslation('title', 'en'))->toBe('English title')
+        ->and($seo->getTranslation('title', 'it'))->toBe('Titolo italiano')
+        ->and(withLocale('it', fn () => Seo::findOrFail($seo->id)->title))->toBe('Titolo italiano');
+});
+
+it('casts robots and schema_overrides to arrays per locale', function () {
+    $seo = Seo::factory()->create([
+        'robots' => ['en' => ['noindex', 'nofollow'], 'it' => []],
+        'schema_overrides' => ['en' => ['headline' => 'Custom headline'], 'it' => []],
+    ]);
+
+    $seo->refresh();
+
+    expect($seo->getTranslation('robots', 'en'))->toBe(['noindex', 'nofollow'])
+        ->and($seo->getTranslation('robots', 'it'))->toBe([])
+        ->and($seo->getTranslation('schema_overrides', 'en'))->toBe(['headline' => 'Custom headline']);
+});
+
+it('casts schema_type to the SchemaType enum', function () {
+    $seo = Seo::factory()->create(['schema_type' => SchemaType::CREATIVE_WORK]);
+
+    expect($seo->fresh()->schema_type)->toBe(SchemaType::CREATIVE_WORK);
+});
+
+it('belongs to its seoable model', function () {
+    $seo = Seo::factory()->create();
+
+    expect($seo->seoable)->toBeInstanceOf(BlogArticle::class);
+});
+
+it('enforces a single seo row per model', function () {
+    $article = BlogArticle::factory()->create();
+    $attributes = ['seoable_id' => $article->id, 'seoable_type' => $article->getMorphClass()];
+
+    Seo::factory()->create($attributes);
+
+    expect(fn () => Seo::factory()->create($attributes))->toThrow(QueryException::class);
+});

--- a/tests/Feature/View/Composers/SeoComposerTest.php
+++ b/tests/Feature/View/Composers/SeoComposerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use App\DataTransferObjects\SeoData;
+use App\View\Composers\SeoComposer;
+use Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRedirectFilter;
+use Mcamara\LaravelLocalization\Middleware\LocaleSessionRedirect;
+
+beforeEach(fn () => $this->withoutVite());
+
+it('renders every section present on the SeoData', function () {
+    $html = view('layouts.public.seo', ['seo_data' => new SeoData(
+        title: 'My Page',
+        description: 'A description',
+        canonical: 'https://example.test/page',
+        robots: 'noindex,nofollow',
+        alternates: [
+            ['hreflang' => 'en', 'href' => 'https://example.test/en/page'],
+            ['hreflang' => 'it', 'href' => 'https://example.test/it/page'],
+        ],
+        open_graph: ['og:title' => 'My Page', 'og:type' => 'article'],
+        twitter: ['twitter:card' => 'summary_large_image'],
+        json_ld: [['@context' => 'https://schema.org', '@type' => 'Article', 'headline' => 'My Page']],
+    )])->render();
+
+    expect($html)
+        ->toContain('<title>My Page</title>')
+        ->toContain('<meta name="description" content="A description">')
+        ->toContain('<meta name="robots" content="noindex,nofollow">')
+        ->toContain('<link rel="canonical" href="https://example.test/page">')
+        ->toContain('<link rel="alternate" hreflang="en" href="https://example.test/en/page">')
+        ->toContain('<link rel="alternate" hreflang="it" href="https://example.test/it/page">')
+        ->toContain('<meta property="og:title" content="My Page">')
+        ->toContain('<meta property="og:type" content="article">')
+        ->toContain('<meta name="twitter:card" content="summary_large_image">')
+        ->toContain('<script type="application/ld+json">')
+        ->toContain('"@type":"Article"')
+        ->toContain('"@context":"https://schema.org"');
+});
+
+it('always emits a title, falling back to the app name', function (?string $title) {
+    $html = view('layouts.public.seo', ['seo_data' => new SeoData(title: $title)])->render();
+
+    expect($html)
+        ->toContain('<title>'.config('app.name').'</title>')
+        ->not->toContain('<title></title>');
+})->with([
+    'null title' => [null],
+    'empty title' => [''],
+]);
+
+it('omits sections that are not present on the SeoData', function () {
+    $html = view('layouts.public.seo', ['seo_data' => new SeoData(title: 'Only a title')])->render();
+
+    expect($html)
+        ->toContain('<title>Only a title</title>')
+        ->not->toContain('<meta name="description"')
+        ->not->toContain('rel="canonical"')
+        ->not->toContain('rel="alternate"')
+        ->not->toContain('property="og:')
+        ->not->toContain('name="twitter:')
+        ->not->toContain('application/ld+json');
+});
+
+it('renders nothing when no SeoData is provided', function () {
+    expect(view('layouts.public.seo', ['seo_data' => null])->render())
+        ->not->toContain('<title')
+        ->not->toContain('<meta')
+        ->not->toContain('<link');
+});
+
+it('escapes JSON-LD so it cannot break out of the script tag', function () {
+    $html = view('layouts.public.seo', ['seo_data' => new SeoData(
+        json_ld: [['@type' => 'Article', 'headline' => '</script><script>alert(1)']],
+    )])->render();
+
+    // The angle brackets are hex-encoded by JSON_HEX_TAG, so the payload cannot
+    // close the surrounding <script> tag.
+    expect($html)
+        ->not->toContain('<script>alert(1)')
+        ->toContain('alert(1)');
+});
+
+it('does not override a SeoData already provided to the layout', function () {
+    $provided = new SeoData(title: 'Provided by the page');
+    $view = view('layouts.public.index', ['seo_data' => $provided]);
+
+    (new SeoComposer)->compose($view);
+
+    expect($view->getData()['seo_data'])->toBe($provided);
+});
+
+it('emits one title, one canonical and one hreflang per locale on a rendered page', function () {
+    // Skip mcamara's locale redirects: without a route cache the prefixed URLs
+    // don't exist in tests, so we render the default locale at "/" directly.
+    $response = $this->withoutMiddleware([
+        LaravelLocalizationRedirectFilter::class,
+        LocaleSessionRedirect::class,
+    ])->get('/');
+
+    $response->assertOk();
+    $html = $response->getContent();
+
+    expect(substr_count($html, '<title'))->toBe(1)
+        ->and(substr_count($html, 'rel="canonical"'))->toBe(1)
+        ->and(substr_count($html, '<link rel="alternate" hreflang='))->toBe(2)
+        // Home opts out of the suffix, so the title is the bare app name.
+        ->and($html)->toContain('<title>'.config('app.name').'</title>');
+});

--- a/tests/Feature/View/Composers/SeoComposerTest.php
+++ b/tests/Feature/View/Composers/SeoComposerTest.php
@@ -21,7 +21,7 @@ it('renders every section present on the SeoData', function () {
         ],
         open_graph: ['og:title' => 'My Page', 'og:type' => 'article'],
         twitter: ['twitter:card' => 'summary_large_image'],
-        json_ld: [['@context' => 'https://schema.org', '@type' => 'Article', 'headline' => 'My Page']],
+        json_ld: [['@type' => 'Article', 'headline' => 'My Page']],
     )])->render();
 
     expect($html)
@@ -35,8 +35,9 @@ it('renders every section present on the SeoData', function () {
         ->toContain('<meta property="og:type" content="article">')
         ->toContain('<meta name="twitter:card" content="summary_large_image">')
         ->toContain('<script type="application/ld+json">')
-        ->toContain('"@type":"Article"')
-        ->toContain('"@context":"https://schema.org"');
+        ->toContain('"@context":"https://schema.org"')
+        ->toContain('"@graph":[')
+        ->toContain('"@type":"Article"');
 });
 
 it('always emits a title, falling back to the app name', function (?string $title) {

--- a/tests/Feature/View/Composers/SeoComposerTest.php
+++ b/tests/Feature/View/Composers/SeoComposerTest.php
@@ -83,13 +83,23 @@ it('escapes JSON-LD so it cannot break out of the script tag', function () {
         ->toContain('alert(1)');
 });
 
-it('does not override a SeoData already provided to the layout', function () {
-    $provided = new SeoData(title: 'Provided by the page');
+it('keeps a page-provided SeoData and only prepends the sitewide schema nodes', function () {
+    $provided = new SeoData(
+        title: 'Provided by the page',
+        json_ld: [['@type' => 'Article', 'headline' => 'Provided by the page']],
+    );
     $view = view('layouts.public.index', ['seo_data' => $provided]);
 
     (new SeoComposer)->compose($view);
 
-    expect($view->getData()['seo_data'])->toBe($provided);
+    $resolved = $view->getData()['seo_data'];
+
+    expect($resolved)->not->toBe($provided)
+        ->and($resolved->title)->toBe('Provided by the page')
+        // Sitewide nodes (WebSite + identity) come first, the page node stays last.
+        ->and($resolved->json_ld)->toHaveCount(3)
+        ->and($resolved->json_ld[2])->toBe(['@type' => 'Article', 'headline' => 'Provided by the page'])
+        ->and($resolved->json_ld[0]['@type'])->toBe('WebSite');
 });
 
 it('emits one title, one canonical and one hreflang per locale on a rendered page', function () {

--- a/tests/Unit/Macros/ReplacePlaceholdersMacroTest.php
+++ b/tests/Unit/Macros/ReplacePlaceholdersMacroTest.php
@@ -55,3 +55,8 @@ it('stringifies non-string replacements', function () {
 it('leaves unmatched placeholders intact', function () {
     expect(Str::replacePlaceholders('{unknown}', []))->toBe('{unknown}');
 });
+
+it('strips unmatched placeholders when asked to', function () {
+    expect(Str::replacePlaceholders('{name}-{unknown}', ['name' => 'John'], strip_unmatched: true))
+        ->toBe('John-');
+});


### PR DESCRIPTION
Custom SEO engine inspired by Yoast/RankMath — fully translatable and switchable
  per language. No new composer dependencies.

  ## What it adds
  - **Layout layer**: an optional `SeoData` DTO rendered by a `layouts/public/seo`
    partial — title (+ separator), meta description, robots, canonical, hreflang
    alternates, Open Graph, Twitter Card, and a single JSON-LD `@graph`.
  - **DB**: a translatable `seo` overrides table (morphOne) and a `seo_settings`
    singleton (self-initializing, no seeder).
  - **Engine** (`HasSeo` trait): merges a model's declared `SeoConfig` defaults with
    stored per-record overrides, resolves `{variables}` via `Str::replacePlaceholders`,
    and produces a per-locale `SeoData`. Crawl rules (status + per-locale noindex)
    are reconciled in one place (`isIndexable`), and the sitemap skips noindex
    locales. Wired into `BlogArticle` (BlogPosting) and `Project` (CreativeWork).
  - **Rendering**: blog/project show pages emit their resolved `SeoData`; the
    to every page's `@graph`.
  - **Filament admin**: a reusable `SeoFields` component (General/Social/Advanced/
    Schema tabs) bound to the `seo` relationship — translatable per active locale,
    and it never persists an empty row. A `SeoSettings` page edits the singleton.

  ## Notable correctness details
  - Per-locale overrides are read **without** the spatie fallback locale, so an
    override set in one language never leaks into another.
  - `{site_name}` and `og:site_name` honour `SeoSetting->name`.
  - The `seo` relationship saves nothing (and prunes an existing empty row) when no
    override is filled, keeping "no overrides" as the absence of a row.
    to every page's `@graph`.
  - **Filament admin**: a reusable `SeoFields` component (General/Social/Advanced/
    Schema tabs) bound to the `seo` relationship — translatable per active locale,
    and it never persists an empty row. A `SeoSettings` page edits the singleton.

  ## Notable correctness details
  - Per-locale overrides are read **without** the spatie fallback locale, so an
    override set in one language never leaks into another.
  - `{site_name}` and `og:site_name` honour `SeoSetting->name`.
  - The `seo` relationship saves nothing (and prunes an existing empty row) when no
    override is filled, keeping "no overrides" as the absence of a row.

  ## Tests
  255 passing (646+ assertions): engine, sitemap, view composer, blade rendering,
  end-to-end head output, and Filament resource/page tests. PHPStan clean
  (`--memory-limit=1G`), Pint clean.